### PR TITLE
add initial small data producer arp and arp script

### DIFF
--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -121,7 +121,7 @@ if [[ -v RUN ]]; then
 	ARGS+=' --run '$RUN
 fi
 if [[ -v EXP ]]; then
-	ARGS+=' --exp $EXP'
+	ARGS+=' --exp '$EXP
 fi
 if [[ -v NEVENTS ]]; then
 	ARGS+=' --nevt '$NEVENTS

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+source /reg/g/psdm/etc/psconda.sh
+ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
+
+batch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$@"
 # Took this from Silke's script, nice implementation
 usage()
 {
@@ -33,14 +37,14 @@ $(basename "$0"):
 		-b|--bsub
 			Run the job through LFS
 EOF
-}
 
+}
 #Look for args we expect, for now ignore other args
 #Since we can have a mix of flags/args and args do in loop
 for arg in "$@" 
 do
 	case $arg in
-		-h| --help)
+		-h|--help)
 			usage
 			exit
 			;;
@@ -74,6 +78,7 @@ do
 			shift
 			;;
 		-n|--nevents)
+			echo "GOt events"
 			NEVENTS="$2"
 			shift
 			shift
@@ -106,44 +111,39 @@ do
 	esac
 done
 
-#Activate Conda Environment
-source /reg/g/psdm/etc/psconda.sh
-
-#Path to script
-ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
-
 #Define cores if we don't have them
 #Set to 1 if single is set
 CORES=${CORES:='1'}
 if [[ "$SINGLE" = true ]]; then
 	CORES=1
 fi
-
+ARGS=''
 #Generate smalldata_producer_arp.py args, for now if
 #Experiment and Run not specified assume it's being handed
 #by the ARP args in the os.environment
 if [[ -v RUN ]]; then
-	ARGS="--run ${RUN} "
+	ARGS=$ARGS' --run '$RUN
 fi
-if [[ -v EXPERIMENT ]]; then
-	ARGS+="--exp ${EXPERIMENT} "
+if [[ -v EXP ]]; then
+	ARGS=$ARGS' --exp $EXP'
 fi
 if [[ -v NEVENTS ]]; then
-	ARGS+="--nevt ${NEVENTS} "
+	ARGS=$ARGS' --nevt '$NEVENTS
 fi
 if [[ -v DIRECTORY ]]; then
-	ARGS+="--dir ${DIRECTORY} "
+	ARGS=$ARGS' --dir '$DIRECTORY
 fi
 if [[ -v OFFLINE ]]; then
-	ARGS+="--offline ${OFFLINE} "
+	ARGS=$ARGS' --offline'
 fi
 if [[ -v GATHER_INTERVAL ]]; then
-	ARGS+="--gather ${GATHER_INTERVAL} "
+	ARGS=$ARGS' --gather '$GATHER_INTERVAL
 fi
 if [[ -v NORECORDER ]]; then
-	ARGS+="--norecorder ${NORECORDER}"
+	ARGS=$ARGS' --norecorder'
 fi
-
 #sbatch --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
-
-sbatch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$ARGS"
+#source /reg/g/psdm/etc/psconda.sh
+#ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
+#python $ABS_PATH/smalldata_producer_arp.py $ARGS
+#sbatch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$ARGS"

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -55,7 +55,7 @@ do
 			shift
 			;;
 		-d|--directory)
-			DIR="$2"
+			DIRECTORY="$2"
 			shift
 			shift
 			;;
@@ -86,12 +86,21 @@ do
 			NORECORDER=true
 			shift
 			;;
+		-o|--offline)
+			OFFLINE=true
+			shift
+			;;
 		-t|--test)
 			TEST=true
 			shift
 			;;
 		-b|--bsub)
 			LFS=true
+			shift
+			;;
+		-g|--gather_interval)
+			GATHER_INTERVAL="$2"
+			shift
 			shift
 			;;
 	esac
@@ -105,11 +114,20 @@ ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
 
 #Define cores if we don't have them
 #Set to 1 if single is set
-CORES=${CORES:='12'}
+CORES=${CORES:='1'}
 if [ "$SINGLE" = true ]; then
 	CORES=1
 fi
 
-#sbatch --nodes=4 --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
+#Generate smalldata_producer_arp.py args
+ARGS="--run ${RUN} "
+ARGS+="--exp ${EXPERIMENT} "
+ARGS+="--nevt ${NEVENTS} "
+ARGS+="--dir ${DIRECTORY} "
+ARGS+="--offline ${OFFLINE} "
+ARGS+="--gather ${GATHER_INTERVAL} "
+ARGS+="--norecorder ${NORECORDER}"
 
-sbatch --nodes=2 --time=5 $ABS_PATH/smalldata_producer_arp.py "$@"
+#sbatch --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
+
+sbatch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$ARGS"

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /reg/g/psdm/etc/psconda.sh
+ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
+
+sbatch --nodes=2 --time=5 $ABS_PATH/smalldata_producer_arp.py "$@"

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -122,11 +122,21 @@ fi
 #Generate smalldata_producer_arp.py args
 ARGS="--run ${RUN} "
 ARGS+="--exp ${EXPERIMENT} "
-ARGS+="--nevt ${NEVENTS} "
-ARGS+="--dir ${DIRECTORY} "
-ARGS+="--offline ${OFFLINE} "
-ARGS+="--gather ${GATHER_INTERVAL} "
-ARGS+="--norecorder ${NORECORDER}"
+if [[ -v NEVENTS ]]; then
+	ARGS+="--nevt ${NEVENTS} "
+fi
+if [[ -v DIRECTORY ]]; then
+	ARGS+="--dir ${DIRECTORY} "
+fi
+if [[ -v OFFLINE ]]; then
+	ARGS+="--offline ${OFFLINE} "
+fi
+if [[ -v GATHER_INTERVAL ]]; then
+	ARGS+="--gather ${GATHER_INTERVAL} "
+fi
+if [[ -v NORECORDER ]]; then
+	ARGS+="--norecorder ${NORECORDER}"
+fi
 
 #sbatch --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
 

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-source /reg/g/psdm/etc/psconda.sh
-ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
-
-batch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$@"
 # Took this from Silke's script, nice implementation
 usage()
 {
@@ -122,28 +118,27 @@ ARGS=''
 #Experiment and Run not specified assume it's being handed
 #by the ARP args in the os.environment
 if [[ -v RUN ]]; then
-	ARGS=$ARGS' --run '$RUN
+	ARGS+=' --run '$RUN
 fi
 if [[ -v EXP ]]; then
-	ARGS=$ARGS' --exp $EXP'
+	ARGS+=' --exp $EXP'
 fi
 if [[ -v NEVENTS ]]; then
-	ARGS=$ARGS' --nevt '$NEVENTS
+	ARGS+=' --nevt '$NEVENTS
 fi
 if [[ -v DIRECTORY ]]; then
-	ARGS=$ARGS' --dir '$DIRECTORY
+	ARGS+=' --dir '$DIRECTORY
 fi
 if [[ -v OFFLINE ]]; then
-	ARGS=$ARGS' --offline'
+	ARGS+=' --offline'
 fi
 if [[ -v GATHER_INTERVAL ]]; then
-	ARGS=$ARGS' --gather '$GATHER_INTERVAL
+	ARGS+=' --gather '$GATHER_INTERVAL
 fi
 if [[ -v NORECORDER ]]; then
-	ARGS=$ARGS' --norecorder'
+	ARGS+=' --norecorder'
 fi
-#sbatch --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
-#source /reg/g/psdm/etc/psconda.sh
-#ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
-#python $ABS_PATH/smalldata_producer_arp.py $ARGS
-#sbatch --nodes=1 --time=5 $ABS_PATH/smalldata_producer_arp.py "$ARGS"
+
+source /reg/g/psdm/etc/psconda.sh
+ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
+sbatch --cpus-per-task=$CORES --time=5 $ABS_PATH/smalldata_producer_arp.py $ARGS

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -115,13 +115,19 @@ ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
 #Define cores if we don't have them
 #Set to 1 if single is set
 CORES=${CORES:='1'}
-if [ "$SINGLE" = true ]; then
+if [[ "$SINGLE" = true ]]; then
 	CORES=1
 fi
 
-#Generate smalldata_producer_arp.py args
-ARGS="--run ${RUN} "
-ARGS+="--exp ${EXPERIMENT} "
+#Generate smalldata_producer_arp.py args, for now if
+#Experiment and Run not specified assume it's being handed
+#by the ARP args in the os.environment
+if [[ -v RUN ]]; then
+	ARGS="--run ${RUN} "
+fi
+if [[ -v EXPERIMENT ]]; then
+	ARGS+="--exp ${EXPERIMENT} "
+fi
 if [[ -v NEVENTS ]]; then
 	ARGS+="--nevt ${NEVENTS} "
 fi

--- a/arp_scripts/submit_small_data.sh
+++ b/arp_scripts/submit_small_data.sh
@@ -1,6 +1,115 @@
 #!/bin/bash
 
+# Took this from Silke's script, nice implementation
+usage()
+{
+cat << EOF
+$(basename "$0"): 
+	Script to launch a smalldata_tools run analysis
+	
+	OPTIONS:
+		-h|--help
+			Definition of options
+		-e|--experiment
+			Experiment name (i.e. cxilr6716)
+		-r|--run
+			Run Number
+		-d|--directory
+			Full path to directory for output file
+		-q|--queue
+			Queue to use on SLURM
+		-c|--cores
+			Number of cores to be utilized
+		-s|--single
+			Run on a single core
+		-n|--nevents
+			Number of events to analyze
+		-l|--locally
+			If specified, will run locally
+		-f|--fast
+			If specified, don't use recorder data
+		-t|--test
+			Run the slurm job as test only to get job info
+		-b|--bsub
+			Run the job through LFS
+EOF
+}
+
+#Look for args we expect, for now ignore other args
+#Since we can have a mix of flags/args and args do in loop
+for arg in "$@" 
+do
+	case $arg in
+		-h| --help)
+			usage
+			exit
+			;;
+		-r|--run) 
+			RUN="$2"
+			shift
+			shift
+			;;
+		-e|--experiment)
+			EXP="$2"
+			shift
+			shift
+			;;
+		-d|--directory)
+			DIR="$2"
+			shift
+			shift
+			;;
+		-q|--queue)
+			QUEUE="$2"
+			shift
+			shift
+			;;
+		-c|--cores)
+			CORES="$2"
+			shift
+			shift
+			;;
+		-s|--single)
+			SINGLE=true
+			shift
+			;;
+		-n|--nevents)
+			NEVENTS="$2"
+			shift
+			shift
+			;;
+		-l|--local)
+			LOCALLY=true
+			shift
+			;;
+		-f|--fast)
+			NORECORDER=true
+			shift
+			;;
+		-t|--test)
+			TEST=true
+			shift
+			;;
+		-b|--bsub)
+			LFS=true
+			shift
+			;;
+	esac
+done
+
+#Activate Conda Environment
 source /reg/g/psdm/etc/psconda.sh
+
+#Path to script
 ABS_PATH=/reg/g/psdm/sw/tools/smalldata_tools/examples
+
+#Define cores if we don't have them
+#Set to 1 if single is set
+CORES=${CORES:='12'}
+if [ "$SINGLE" = true ]; then
+	CORES=1
+fi
+
+#sbatch --nodes=4 --cpus-per-task=$CORES --test-only $ABS_PATH/smalldata_producer_arp.py
 
 sbatch --nodes=2 --time=5 $ABS_PATH/smalldata_producer_arp.py "$@"

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -112,6 +112,7 @@ logger.debug('Analayzing data for EXP:{0} - RUN:{1}'.format(args.exp, args.run))
 hutch = exp[:3].upper()
 if hutch not in HUTCHES:
     logger.debug('Could not find {0} in list of available hutches'.format(hutch))
+	sys.exit()	
 
 # Get current exp and run
 cur_exp = get_cur_exp(hutch, station)

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+import numpy as np
+import psana
+import time
+import argparse
+import socket
+import os
+import logging 
+import requests
+import sys
+from glob import glob
+
+# General Workflow
+# This is meant for arp which means we will always have an exp and run
+# Check if this is a current experiment
+# If it is current, check in ffb for xtc data, if not there, default to psdm
+
+# TODO: Fix this
+sys.path.append('/reg/g/psdm/sw/tools/smalldata_tools')
+from smalldata_tools.utilities import printMsg
+from smalldata_tools.SmallDataUtils import setParameter, defaultDetectors, detData
+from smalldata_tools.SmallDataDefaultDetector import ttRawDetector, wave8Detector, epicsDetector
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+# Constants
+HUTCHES = [
+	'AMO',
+	'SXR',
+	'XPP',
+	'XCS',
+	'MFX',
+	'CXI',
+	'MEC'
+]
+
+WS_URL = 'https://pswww.slac.stanford.edu/ws/lgbk'
+ACTIVE_EXP_EXT = '/lgbk/ws/activeexperiment_for_instrument_station'
+FFB_BASE = '/reg/d/ffb'
+PSDM_BASE = '/reg/d/psdm'
+SD_EXT = '/hdf5/smalldata'
+WS_CUR_RUN = '/ws/current_run'
+
+# Define Args
+parser = argparse.ArgumentParser()
+parser.add_argument('--run', help='run', type=str, default=os.environ['RUN_NUM'])
+parser.add_argument('--exp', help='experiment name', type=str, default=os.environ['EXPERIMENT'])
+parser.add_argument('--stn', help='hutch station', type=int, default=0)
+parser.add_argument('--nevt', help='number of events', type=int, default=1e9)
+parser.add_argument('--dir', help='directory for output files (def <exp>/hdf5/smalldata)')
+parser.add_argument('--offline', help='run offline (def for current exp from ffb)')
+parser.add_argument('--gather', help='gather interval', type=int, default=100)
+parser.add_argument("--norecorder", help="ignore recorder streams", action='store_true')
+args = parser.parse_args()
+
+###### Helper Functions ##########
+
+def get_cur_exp(hutch, station):
+	"""Get the active experiment for the given hutch"""
+	endpoint = ''.join([WS_URL, ACTIVE_EXP_EXT])
+	args = {'instrument_name': hutch, 'station': station}
+	r = requests.get(endpoint, args)
+	active_exp = str(r.json().get('value', {}).get('name'))
+	
+	return active_exp
+
+def get_cur_run(exp):
+	"""Get current run for current experiment"""
+	endpoint = ''.join([WS_URL, '/lgbk/', exp, WS_CUR_RUN])
+	run_info = requests.get(endpoint).json()['value']
+	
+	return str(int(run_info['num']))
+
+def get_xtc_files(base, hutch, run):
+	"""File all xtc files for given experiment and run"""
+	run_format = ''.join(['r', run.zfill(4)])
+	data_dir = ''.join([base, '/', hutch.lower(), '/', exp, '/xtc'])
+	xtc_files = glob(''.join([data_dir, '/', '*', '-', run_format, '*']))
+
+	return xtc_files
+
+def get_sd_file(write_dir, exp, hutch):
+	"""Generate directory to write to, create file name"""
+	if write_dir is None:
+		write_dir = ''.join([PSDM_BASE, '/', hutch, '/', exp, SD_EXT])
+	h5_f_name = ''.join([write_dir, '/', exp, '_Run', run.zfill(4), '.h5'])
+	logger.debug('Will write small data file to {0}'.format(h5_f_name))
+
+	if not os.path.isdir(write_dir):
+		logger.debug('{0} does not exist, creating directory'.format(write_dir))
+		try:
+			os.mkdir(write_dir)
+		except OSError as e:
+			logger.debug('Unable to make directory {0} for output, exiting: {1}'.format(write_dir, e))
+			sys.exit()
+
+	return h5_f_name
+
+##### START SCRIPT ########
+
+# Define hostname
+hostname = socket.gethostname()
+
+# Parse hutch name from experiment and check it's a valid hutch
+exp = args.exp
+run = args.run
+station = args.stn
+logger.debug('Analayzing data for EXP:{0} - RUN:{1}'.format(args.exp, args.run))
+
+hutch = exp[:3].upper()
+if hutch not in HUTCHES:
+    logger.debug('Could not find {0} in list of available hutches'.format(hutch))
+
+# Get current exp and run
+cur_exp = get_cur_exp(hutch, station)
+cur_run = get_cur_run(cur_exp)  # This might be unecessary
+
+xtc_files = []
+# If experiment matches, check for files in ffb
+if cur_exp == exp:
+	xtc_files = get_xtc_files(FFB_BASE, hutch, cur_run)
+
+# If not a current experiment or files in ffb, look in psdm
+if not xtc_files:
+	logger.debug('Either not a current exp or files not in ffb, looking in psdm')
+	xtc_files = get_xtc_files(PSDM_BASE, hutch, cur_run)
+
+# Get output file, check if we can write to it
+h5_f_name = get_sd_file(args.dir, exp, hutch)
+
+# Define data source name and generate data source object, don't understand all conditions yet
+ds_name = ''.join(['exp=', exp, ':run=', run, ':smd', ':stream=0-79'])
+try:
+	ds = psana.MPIDataSource(ds_name)
+except Exception as e:
+	logger.debug('Could not instantiate MPIDataSource with {0): {1}'.format(ds_name, e))
+	sys.exit()
+
+# Generate smalldata object
+small_data = ds.small_data(h5_f_name, gather_interval=args.gather)
+
+# Not sure why, but here
+if ds.rank is 0:
+	logger.debug('psana conda environemnt is {0}'.format(os.environ['CONDA_DEFAULT_ENV']))
+
+# gather default dets and add to data
+default_dets = defaultDetectors(hutch.lower())
+config_data = {det.name: det.params_as_dict() for det in default_dets}
+small_data.save({'UserDataCfg': config_data})
+
+max_iter = args.nevt / ds.size
+for evt_num, evt in enumerate(ds.events()):
+	if evt_num > max_iter:
+		break
+
+	det_data = detData(default_dets, evt)
+	small_data.event(det_data)
+
+logger.debug('rank {0} on {1} is finished'.format(ds.rank, hostname))
+small_data.save()
+logger.debug('Saved all small data')
+

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -45,8 +45,8 @@ WS_CUR_RUN = '/ws/current_run'
 
 # Define Args
 parser = argparse.ArgumentParser()
-parser.add_argument('--run', help='run', type=str, default=os.environ['RUN_NUM'])
-parser.add_argument('--exp', help='experiment name', type=str, default=os.environ['EXPERIMENT'])
+parser.add_argument('--run', help='run', type=str, default=os.environ.get('RUN_NUM', ''))
+parser.add_argument('--exp', help='experiment name', type=str, default=os.environ.get('EXPERIMENT', ''))
 parser.add_argument('--stn', help='hutch station', type=int, default=0)
 parser.add_argument('--nevt', help='number of events', type=int, default=1e9)
 parser.add_argument('--dir', help='directory for output files (def <exp>/hdf5/smalldata)')
@@ -64,7 +64,7 @@ def get_cur_exp(hutch, station):
 	endpoint = ''.join([WS_URL, ACTIVE_EXP_EXT])
 	args = {'instrument_name': hutch, 'station': station}
 	r = requests.get(endpoint, args)
-	active_exp = str(r.json().get('value', ''))
+	active_exp = str(r.json().get('value', {'name':''}).get('name'))
 	
 	return active_exp
 

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -58,11 +58,13 @@ args = parser.parse_args()
 ###### Helper Functions ##########
 
 def get_cur_exp(hutch, station):
-	"""Get the active experiment for the given hutch"""
+	"""Get the active experiment for the given hutch, returns 'None' if no active
+	experimets for given hutch
+	"""
 	endpoint = ''.join([WS_URL, ACTIVE_EXP_EXT])
 	args = {'instrument_name': hutch, 'station': station}
 	r = requests.get(endpoint, args)
-	active_exp = str(r.json().get('value', {}).get('name'))
+	active_exp = str(r.json().get('value', None))
 	
 	return active_exp
 

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -54,7 +54,7 @@ parser.add_argument('--offline', help='run offline (def for current exp from ffb
 parser.add_argument('--gather', help='gather interval', type=int, default=100)
 parser.add_argument("--norecorder", help="ignore recorder streams", action='store_true')
 args = parser.parse_args()
-
+print('here are args ', args)
 ###### Helper Functions ##########
 
 def get_cur_exp(hutch, station):

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -54,7 +54,8 @@ parser.add_argument('--offline', help='run offline (def for current exp from ffb
 parser.add_argument('--gather', help='gather interval', type=int, default=100)
 parser.add_argument("--norecorder", help="ignore recorder streams", action='store_true')
 args = parser.parse_args()
-print('here are args ', args)
+logger.debug('Args to be used for small data run: {0}'.format(args))
+
 ###### Helper Functions ##########
 
 def get_cur_exp(hutch, station):

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -58,13 +58,13 @@ args = parser.parse_args()
 ###### Helper Functions ##########
 
 def get_cur_exp(hutch, station):
-	"""Get the active experiment for the given hutch, returns 'None' if no active
+	"""Get the active experiment for the given hutch, returns '' if no active
 	experimets for given hutch
 	"""
 	endpoint = ''.join([WS_URL, ACTIVE_EXP_EXT])
 	args = {'instrument_name': hutch, 'station': station}
 	r = requests.get(endpoint, args)
-	active_exp = str(r.json().get('value', None))
+	active_exp = str(r.json().get('value', ''))
 	
 	return active_exp
 

--- a/examples/smalldata_producer_arp.py
+++ b/examples/smalldata_producer_arp.py
@@ -111,7 +111,7 @@ logger.debug('Analayzing data for EXP:{0} - RUN:{1}'.format(args.exp, args.run))
 
 hutch = exp[:3].upper()
 if hutch not in HUTCHES:
-    logger.debug('Could not find {0} in list of available hutches'.format(hutch))
+	logger.debug('Could not find {0} in list of available hutches'.format(hutch))
 	sys.exit()	
 
 # Get current exp and run

--- a/smalldata_tools/SmallDataUtils.py
+++ b/smalldata_tools/SmallDataUtils.py
@@ -138,7 +138,7 @@ def cxiDetectors(beamCodes=[[162],[]]):
     dets.append(bmmonDetector('CXI-DG2-BMMON','ipm_dg2'))
     dets.append(bmmonDetector('CXI-DG3-BMMON','ipm_dg3'))
     dets.append(ttDetector(baseName='CXI:TTSPEC:'))
-    dets.append(impDetector('Sc1Imp'))
+    #dets.append(impDetector('Sc1Imp'))
     dets.append(damageDetector())
     try:
         dets.append(encoderDetector('XRT-USB-ENCODER-01','xrt_enc'))

--- a/smalldata_tools/SmallDataUtils.py
+++ b/smalldata_tools/SmallDataUtils.py
@@ -138,7 +138,7 @@ def cxiDetectors(beamCodes=[[162],[]]):
     dets.append(bmmonDetector('CXI-DG2-BMMON','ipm_dg2'))
     dets.append(bmmonDetector('CXI-DG3-BMMON','ipm_dg3'))
     dets.append(ttDetector(baseName='CXI:TTSPEC:'))
-    #dets.append(impDetector('Sc1Imp'))
+    dets.append(impDetector('Sc1Imp'))
     dets.append(damageDetector())
     try:
         dets.append(encoderDetector('XRT-USB-ENCODER-01','xrt_enc'))

--- a/smalldata_tools/SmallDataUtils.py
+++ b/smalldata_tools/SmallDataUtils.py
@@ -138,7 +138,10 @@ def cxiDetectors(beamCodes=[[162],[]]):
     dets.append(bmmonDetector('CXI-DG2-BMMON','ipm_dg2'))
     dets.append(bmmonDetector('CXI-DG3-BMMON','ipm_dg3'))
     dets.append(ttDetector(baseName='CXI:TTSPEC:'))
-    dets.append(impDetector('Sc1Imp'))
+    try:
+        dets.append(impDetector('Sc1Imp'))
+    except:
+        pass
     dets.append(damageDetector())
     try:
         dets.append(encoderDetector('XRT-USB-ENCODER-01','xrt_enc'))

--- a/smalldata_tools/utilities.py
+++ b/smalldata_tools/utilities.py
@@ -9,7 +9,7 @@ from scipy import optimize
 from scipy import ndimage
 from scipy import signal
 from scipy import sparse
-from scipt.stats import gaussian_kde
+from scipy.stats import gaussian_kde
 from matplotlib import pyplot as plt
 import resource
 from itertools import izip, count


### PR DESCRIPTION
Add the arp version of SmallDataProducer.py (basic)
Add the bash script to kick off ARP run (basic)
Fix typo for Scipy
Comment out detector (for now), that apparently doesn't exist in impDetector now?

Initial working version,  next PR will be to expand bash submit script to include all the options

ARP output:
DEBUG:__main__:Analayzing data for EXP:cxic00318 - RUN:5
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): pswww.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://pswww.slac.stanford.edu:443 "GET /ws/lgbk/lgbk/ws/activeexperiment_for_instrument_station?station=0&instrument_name=CXI HTTP/1.1" 200 688
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): pswww.slac.stanford.edu:443
DEBUG:urllib3.connectionpool:https://pswww.slac.stanford.edu:443 "GET /ws/lgbk/lgbk/cxic00318/ws/current_run HTTP/1.1" 200 8515
DEBUG:__main__:Either not a current exp or files not in ffb, looking in psdm
DEBUG:__main__:Will write small data file to /reg/d/psdm/CXI/cxic00318/hdf5/smalldata/cxic00318_Run0005.h5
DEBUG:__main__:psana conda environemnt is ana-1.5.8
DEBUG:__main__:rank 0 on psanagpu103 is finished
DEBUG:__main__:Saved all small data