### PR TITLE
set default pedestal for acqiris to that ROI works

### DIFF
--- a/smalldata_tools/DetObject.py
+++ b/smalldata_tools/DetObject.py
@@ -342,6 +342,7 @@ class WaveformObject(DetObjectClass):
         #super().__init__(det,env,run, **kwargs)
         super(WaveformObject, self).__init__(det,env,run, **kwargs)
         self.common_mode = kwargs.get('common_mode', -1)
+        self.ped = None
         self.rms = None
         self.mask = None
         self.wfx = None


### PR DESCRIPTION
add self.ped=None for waveform detectors so that the rewritten ROI function still works.