### PR TITLE
Enh/centerpix

### DIFF
--- a/smalldata_tools/DetObject.py
+++ b/smalldata_tools/DetObject.py
@@ -444,12 +444,6 @@ class CameraObject(DetObjectClass):
         except:
             self.x = None
             self.y = None
-        self.areas = None
-        if not self.maskCentral:
-            try:
-                self.areas = self.det.areas(run)
-            except:
-                pass
 
     def getData(self, evt):
         super(CameraObject, self).getData(evt)
@@ -664,6 +658,14 @@ class TiledCameraObject(CameraObject):
             self.ix=self.x #need to change this so ix & iy are integers!
             self.iy=self.y
         self._needsGeo=True #FIX ME: not sure it should be here.            
+
+        self.areas = None
+        if not self.maskCentral:
+            try:
+                self.areas = self.det.areas(run)
+            except:
+                pass
+
     def getData(self, evt):
         super(TiledCameraObject, self).getData(evt)
 
@@ -764,9 +766,14 @@ class JungfrauObject(TiledCameraObject):
             self.evt.dat = self.det.calib(evt, cmpars=(7,2,10,10), mbits=mbits) #correction in columns
         elif self.common_mode%100==7:
             self.evt.dat = self.det.calib(evt, cmpars=(7,3,10,10), mbits=mbits) #correction in rows&columns
+
         #override gain if desired
         if self.local_gain is not None and self.local_gain.shape == self.evt.dat.shape and self.common_mode in [7,71,72,0]:
             self.evt.dat*=self.local_gain   #apply own gain
+
+        #correct for area of pixels.
+        if self.areas is not None:
+            self.evt.dat/=self.areas
 
 class CsPadObject(TiledCameraObject):  
     def __init__(self, det,env,run,**kwargs):
@@ -815,6 +822,10 @@ class CsPadObject(TiledCameraObject):
         #override gain if desired
         if self.local_gain is not None and self.local_gain.shape == self.evt.dat.shape and self.common_mode in [1,5,55,10]:
             self.evt.dat*=self.local_gain   #apply own gain
+
+        #correct for area of pixels.
+        if self.areas is not None:
+            self.evt.dat/=self.areas
 
 class CsPad2MObject(CsPadObject):  
     def __init__(self, det,env,run,**kwargs):
@@ -902,6 +913,10 @@ class EpixObject(TiledCameraObject):
             self.evt.dat*=self.local_gain   #apply own gain
         elif self.local_gain is None and self.gain is not None and self.gain.shape == self.evt.dat.shape and self.common_mode in [45,46,47]:
             self.evt.dat*=self.gain   #apply gain after own common mode correction
+
+        #correct for area of pixels.
+        if self.areas is not None:
+            self.evt.dat/=self.areas
 
         #store environmental row 
         try:
@@ -1020,6 +1035,10 @@ class Epix10kObject(TiledCameraObject):
         #override gain if desired -- this looks like CsPad.
         if self.local_gain is not None and self.local_gain.shape == self.evt.dat.shape and self.common_mode in [1,5,55,10]:
             self.evt.dat*=self.local_gain   #apply own gain
+
+        #correct for area of pixels.
+        if self.areas is not None:
+            self.evt.dat/=self.areas
 
         #store environmental row 
         try:


### PR DESCRIPTION
Philip pointed out that the Detecorclass returns an array with the pixel area. If you use this to correct the center pixels, then you can get decent looking images without masking this area, leaving more data to be used. The standard image-functions will NOT duplicate these pixels, so it's not 100% correct and by default we will continue to mask the center pixels.

In addition, we use the mask now also for tiff-file production (from the hdf5 files, the user is expected to apply the mask to the ROI to allow them to decide if they would like to use/study masked pixels).