### PR TITLE
finally include the var/flat arrays as sparsifyFunc option

### DIFF
--- a/smalldata_tools/SmallDataUtils.py
+++ b/smalldata_tools/SmallDataUtils.py
@@ -323,7 +323,7 @@ def getUserData(det):
             newDict['ragged_%s'%(key.replace('ragged_',''))] = det_dict[key]
         elif key.find('var')>=0:
             fname = key.split('_')[-1]
-            dname = key.replace('_%s'%fname,'').replace('_var','')
+            dname = key.replace(f'_{fname}','').replace('_var','')
             if 'var_%s'%dname in newDict:
                 newDict[f'var_{dname}'][fname] = det_dict[key]
             else:

--- a/smalldata_tools/SmallDataUtils.py
+++ b/smalldata_tools/SmallDataUtils.py
@@ -321,6 +321,15 @@ def getUserData(det):
     for key in det_dict:
         if key.find('ragged')>=0:
             newDict['ragged_%s'%(key.replace('ragged_',''))] = det_dict[key]
+        elif key.find('var')>=0:
+            fname = key.split('_')[-1]
+            dname = key.replace('_%s'%fname,'').replace('_var','')
+            if 'var_%s'%dname in newDict:
+                newDict[f'var_{dname}'][fname] = det_dict[key]
+            else:
+                newDict[f'var_{dname}'] = {fname : det_dict[key]}
+
+
         else:
             newDict['%s'%(key)] = det_dict[key]
     det_dict = newDict

--- a/smalldata_tools/ana_funcs/sparsifyFunc.py
+++ b/smalldata_tools/ana_funcs/sparsifyFunc.py
@@ -75,7 +75,12 @@ class sparsifyFunc(DetObjectFunc):
             
             
         #now fix shape of data in dict.
-        if self.nData is not None:
+        if self.nData == 0:
+            data_dict = ret_dict
+            ret_dict = {}
+            for key, d in data_dict.items():
+                ret_dict[f'ragged_{key}'] = d
+        elif self.nData is not None:                
             for key in ret_dict.keys():
                 if ret_dict[key].shape[0] >= self.nData:
                     ret_dict[key]=ret_dict[key][:self.nData]
@@ -88,7 +93,7 @@ class sparsifyFunc(DetObjectFunc):
             data_dict = ret_dict
             ret_dict = {}
             for key, d in data_dict.items():
-                ret_dict[f'ragged_{key}'] = d
+                ret_dict[f'var_{key}'] = d
 
         subfuncResults = self.processFuncs()
         for k in subfuncResults:


### PR DESCRIPTION
Now not specifying nData will give you a 'var array'. nData==0 is a ragged array and nData > 0 the good, old rectangular array.

h5ls  /reg/d/psdm/mec/mecx45520/scratch/snelson/mecx52320_Run0286.h5/epix100a_1_XTCS/var_droplet_sparse
col                      Dataset {119/Inf}
data                     Dataset {119/Inf}
npix                     Dataset {119/Inf}
row                      Dataset {119/Inf}
tile                     Dataset {119/Inf}

h5ls -d  /reg/d/psdm/mec/mecx45520/scratch/snelson/mecx52320_Run0286.h5/epix100a_1_XTCS/var_droplet_sparse_len
var_droplet_sparse_len   Dataset {3/Inf}
    Data:
        (0) 24, 44, 51

Code to read this will be similar to the changes coming up for the more general droplet2phot implementation.