### PR TITLE
PedestalPlot reports number of bad pixels as run params for each detector.

### DIFF
--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -9,6 +9,7 @@ import os
 import argparse
 import sys
 import logging
+import requests
 import socket
 try:
     basestring

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -10,6 +10,7 @@ import argparse
 import sys
 import logging
 import requests
+from requests.auth import HTTPBasicAuth
 import socket
 try:
     basestring

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -411,7 +411,7 @@ def getPixelStatus(det_name, run):
 def countBadPixels(det_name, run):
     status = getPixelStatus(det_name, run)
     status_sum = status.sum(axis=0)
-    return (status_sum>0).sum()
+    return int((status_sum>0).sum())
 
 def plotPedestals(expname='mfxc00118', run=364, save_elog=False, make_ped_imgs=False, make_ped_data_imgs=False,
                  detImgMaxSize=400):


### PR DESCRIPTION
Tested successfully on run 4 of mfxlu7521 
![image](https://user-images.githubusercontent.com/4610338/197916758-dd5ff5ae-1f62-45e4-a766-ed3381999100.png)


```bash
[fpoitevi@psanagpu108 scratch]$ tail -f slurm-425643.out
Working on plots for  epix10k2M
Made Directory to save data: /reg/d/psdm/mfx/mfxlu7521/stats/summary/Pedestals/Pedestals_Run004
URL: https://pswww.slac.stanford.edu/ws-auth/lgbk//run_control/mfxlu7521/ws/add_run_params
<Response [200]>
```

![image](https://user-images.githubusercontent.com/4610338/197916611-8714a237-b046-4df0-b77d-b10d97a0b4f0.png)
