### PR TITLE
Add external mask parameter to MakeMask

### DIFF
--- a/smalldata_tools/BaseSmallDataAna_psana.py
+++ b/smalldata_tools/BaseSmallDataAna_psana.py
@@ -1108,7 +1108,7 @@ class BaseSmallDataAna_psana(object):
         for thismask in mask[1:]:
             totmask = np.logical_or(totmask,thismask)
 
-        if extMask is not None:
+        if extMask is None:
             prompt = "Invert [y/n]? (n/no inversion: masked pixels will get rejected)?\n"
         else:
             prompt = "Does the ext. mask have 0 values for masked pixels [y/n] (n: non-zero pixels are rejected)?\n"

--- a/smalldata_tools/BaseSmallDataAna_psana.py
+++ b/smalldata_tools/BaseSmallDataAna_psana.py
@@ -767,7 +767,7 @@ class BaseSmallDataAna_psana(object):
         return
     
             
-    def MakeMask(self, detname=None, limits=[5,99.5], singleTile=-1):
+    def MakeMask(self, detname=None, limits=[5,99.5], singleTile=-1, extMask=None):
         detname, img, avImage = self.getAvImage(detname=None)
 
         plotMax = np.nanpercentile(img, limits[1])
@@ -814,7 +814,7 @@ class BaseSmallDataAna_psana(object):
         
         mask=[]
         mask_r_nda=None
-        select=True
+        select=extMask is None  # Short-circuit the loop if given an external mask.
         while select:
             fig=plt.figure(figsize=(12,10))
             gs=gridspec.GridSpec(1,2,width_ratios=[2,1])
@@ -1090,6 +1090,18 @@ class BaseSmallDataAna_psana(object):
                 select = False
 
         #end of mask creating loop
+
+        if extMask is not None:
+            if extMask.shape != self.__dict__[detname].rawShape:
+                print("extMask is the wrong shape: %s actual, %s desired." % (
+                      extMask.shape, self.__dict__[detname].rawShape))
+                return None
+            if extMask.dtype != np.dtype('int64'):
+                print("extMask is the wrong type: %s actual, %s desired." % (
+                      extMask.shape, np.dtype('int64')))
+                return None
+            mask = [extMask]
+
         if len(mask)==0:
             return
         totmask = mask[0]

--- a/smalldata_tools/BaseSmallDataAna_psana.py
+++ b/smalldata_tools/BaseSmallDataAna_psana.py
@@ -1108,7 +1108,11 @@ class BaseSmallDataAna_psana(object):
         for thismask in mask[1:]:
             totmask = np.logical_or(totmask,thismask)
 
-        if raw_input("Invert [y/n]? (n/no inversion: masked pixels will get rejected)?\n") in ["y","Y"]:
+        if extMask is not None:
+            prompt = "Invert [y/n]? (n/no inversion: masked pixels will get rejected)?\n"
+        else:
+            prompt = "Does the ext. mask have 0 values for masked pixels [y/n] (n: non-zero pixels are rejected)?\n"
+        if raw_input(prompt) in ["y","Y"]:
             totmask = (totmask.astype(bool)).astype(int)
         else:
             totmask = (~(totmask.astype(bool))).astype(int)

--- a/smalldata_tools/BaseSmallDataAna_psana.py
+++ b/smalldata_tools/BaseSmallDataAna_psana.py
@@ -32,7 +32,7 @@ except NameError:
 
 import smalldata_tools.SmallDataAna as sda
 
-from smalldata_tools.DetObject import DetObject
+from smalldata_tools.DetObject import DetObject, DetObjectClass
 from smalldata_tools.SmallDataUtils import getUserData
 from smalldata_tools.utilities import printR
 from smalldata_tools.utilities import addToHdf5
@@ -294,7 +294,7 @@ class BaseSmallDataAna_psana(object):
         if len(img.shape)>2:
             image = self.__dict__[detname].det.image(self.run, img)
             if image is None:
-                if self.__dict__[detname].det.dettype != 30:
+                if self.__dict__[detname].det.dettype != DetObjectClass.Icarus:
                     image = img.squeeze()
                 else:
                     imgNew = img[0]
@@ -415,7 +415,7 @@ class BaseSmallDataAna_psana(object):
         gs=gridspec.GridSpec(1,2,width_ratios=[2,1])
 
         needsGeo=False
-        if self.__dict__[detname].det.dettype==26:
+        if self.__dict__[detname].det.dettype==DetObjectClass.Jungfrau:
             if self.__dict__[detname].ped[0].shape != self.__dict__[detname].imgShape:
                 needsGeo=True
         elif self.__dict__[detname].ped.shape != self.__dict__[detname].imgShape:
@@ -668,7 +668,7 @@ class BaseSmallDataAna_psana(object):
         extent=[x.min(), x.max(), y.min(), y.max()]
 
         if needsGeo:
-            if self.__dict__[detname].det.dettype==30:
+            if self.__dict__[detname].det.dettype==DetObjectClass.Icarus:
                 if singleTile<0:
                     print('we need to select a tile for the icarus')
                     return
@@ -778,7 +778,7 @@ class BaseSmallDataAna_psana(object):
         if self.__dict__[detname].ped.shape != self.__dict__[detname].imgShape:
             needsGeo=True
 
-        if self.__dict__[detname].det.dettype==30:
+        if self.__dict__[detname].det.dettype==DetObjectClass.Icarus:
             needsGeo=False
             if singleTile<0 or singleTile>= img.shape[0]:
                 image = img.sum(axis=0)
@@ -804,7 +804,7 @@ class BaseSmallDataAna_psana(object):
         iy = self.__dict__[detname+'_iy']
         extent=[x.min(), x.max(), y.min(), y.max()]
         #print('DEBUG: extent(x,y min,max)',extent)
-        if self.__dict__[detname].det.dettype==30:
+        if self.__dict__[detname].det.dettype==DetObjectClass.Icarus:
             if singleTile<0 or singleTile>= img.shape[0]:
                 x=x[0]
                 y=y[0]
@@ -846,7 +846,7 @@ class BaseSmallDataAna_psana(object):
                 else:
                     mask_r_nda = mask_roi
                     plt.subplot(gs[1]).imshow(mask_r_nda)
-                    if self.__dict__[detname].det.dettype==30:
+                    if self.__dict__[detname].det.dettype==DetObjectClass.Icarus:
                         maskTuple=[mask_r_nda for itile in range(self.__dict__[detname].ped.shape[0])]
                         mask_r_nda = np.array(maskTuple)
                 print('mask from rectangle (shape):',mask_r_nda.shape)
@@ -866,7 +866,7 @@ class BaseSmallDataAna_psana(object):
             elif shape=='c':
                 fig=plt.figure(figsize=(12,10))
                 gs=gridspec.GridSpec(1,2,width_ratios=[2,1])
-                if det.dettype==30:
+                if det.dettype==DetObjectClass.Icarus:
                     plt.subplot(gs[0]).imshow(image,
                                               clim=[plotMin,plotMax],
                                               interpolation='None',
@@ -879,7 +879,7 @@ class BaseSmallDataAna_psana(object):
                 if raw_input("Select center by mouse?\n") in ["y","Y"]:
                     c=ginput(1)
                     cx=c[0][0];cy=c[0][1]
-                    print('Corrdinates of selected center: ',cx,' ',cy)
+                    print('Coordinates of selected center: ',cx,' ',cy)
                 else:
                     ctot = raw_input("center (x y)?\n")
                     c = ctot.split(' ');cx=float(c[0]);cy=float(c[1]);
@@ -918,17 +918,17 @@ class BaseSmallDataAna_psana(object):
                                               clim=[plotMin,plotMax],
                                               interpolation='None',
                                               extent=(x.min(),x.max(),y.min(),y.max()))
-                elif det.dettype==13:
+                elif det.dettype==DetObjectClass.Epix:
                     plt.subplot(gs[0]).imshow(np.rot90(image),
                                               clim=[plotMin,plotMax],
                                               interpolation='None',
                                               extent=(x.min(),x.max(),y.min(),y.max()))
-                elif det.dettype==19:
+                elif det.dettype==DetObjectClass.Rayonix:
                     plt.subplot(gs[0]).imshow(image,
                                               clim=[plotMin,plotMax],
                                               interpolation='None',
                                               extent=(x.min(),x.max(),y.min(),y.max()))
-                elif det.dettype==30:
+                elif det.dettype==DetObjectClass.Icarus:
                     plt.subplot(gs[0]).imshow(np.rot90(image),
                                               clim=[plotMin,plotMax],
                                               interpolation='None',
@@ -948,7 +948,7 @@ class BaseSmallDataAna_psana(object):
                     plt.subplot(gs[1]).imshow(det.image(self.run,mask_r_nda))
                 else:
                     plt.subplot(gs[1]).imshow(mask_r_nda)
-                if self.__dict__[detname].det.dettype==30:
+                if self.__dict__[detname].det.dettype==DetObjectClass.Icarus:
                     maskTuple=[mask_r_nda for itile in range(self.__dict__[detname].ped.shape[0])]
                     mask_r_nda = np.array(maskTuple)
                 print('mask from polygon (shape):',mask_r_nda.shape)
@@ -957,12 +957,14 @@ class BaseSmallDataAna_psana(object):
                 gsPed=gridspec.GridSpec(1,2,width_ratios=[1,1])
                 if shape=='d':
                     pedResult = det.pedestals(self.run)
-                    if det.dettype in [26,29,32,33]:
+                    if det.dettype in [DetObjectClass.Jungfrau, DetObjectClass.Epix10k,
+                                       DetObjectClass.Epix10k2M, DetObjectClass.Epix10k2M_quad]:
                         pedResult = pedResult[0]
                     hstPed = np.histogram(pedResult.flatten(), np.arange(0, pedResult.max()*1.05))
                 else:
                     pedResult = det.rms(self.run)
-                    if det.dettype in [26,29,32,33]:
+                    if det.dettype in [DetObjectClass.Jungfrau, DetObjectClass.Epix10k,
+                                       DetObjectClass.Epix10k2M, DetObjectClass.Epix10k2M_quad]:
                         pedResult = pedResult[0]
                     hstPed = np.histogram(pedResult.flatten(), np.arange(0, pedResult.max()*1.05,0.05))
                 if needsGeo:
@@ -1060,7 +1062,7 @@ class BaseSmallDataAna_psana(object):
                 if needsGeo:
                     plt.imshow(det.image(self.run,image_mask),clim=[plotMin,plotMax])
                 else:
-                    if (self.__dict__[detname].det.dettype==30):
+                    if (self.__dict__[detname].det.dettype==DetObjectClass.Icarus):
                         if singleTile<0 or singleTile>= img.shape[0]:
                             image = image_mask.sum(axis=0)
                         else:
@@ -1101,11 +1103,11 @@ class BaseSmallDataAna_psana(object):
 
         self.__dict__['_mask_'+avImage]=totmask
 
-        if  det.dettype == 2:
+        if  det.dettype == DetObjectClass.CsPad:
             mask=totmask.reshape(2,185*388).transpose(1,0)
-        elif det.dettype == 1:
+        elif det.dettype == DetObjectClass.CsPad2M:
             mask=totmask.reshape(32*185,388)
-        elif det.dettype == 13:
+        elif det.dettype == DetObjectClass.Epix:
             mask=totmask.reshape(704,768)
         else:
             mask=totmask
@@ -1113,15 +1115,15 @@ class BaseSmallDataAna_psana(object):
         #cspad save as 5920 lines, 388 entries
         if raw_input("Save to calibdir?\n") in ["y","Y"]:
             srcStr=det.source.__str__().replace('Source("DetInfo(','').replace(')")','')
-            if det.dettype==2:
+            if det.dettype==DetObjectClass.CsPad:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad2x2::CalibV1/%s/pixel_mask/'%(self.expname[:3],self.expname,srcStr)
-            elif det.dettype==1:
+            elif det.dettype==DetObjectClass.CsPad2M:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad::CalibV1/%s/pixel_mask/'%(self.expname[:3],self.expname,srcStr)        
-            elif det.dettype==13:
+            elif det.dettype==DetObjectClass.Epix:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix100a::CalibV1/%s/pixel_mask/'%(self.expname[:3],self.expname,srcStr)
-            elif det.dettype==19:
+            elif det.dettype==DetObjectClass.Rayonix:
                 dirname='/reg/d/psdm/%s/%s/calib/Camera::CalibV1/%s/pixel_mask/'%(self.expname[:3],self.expname,srcStr)        
-            elif det.dettype==32:
+            elif det.dettype==DetObjectClass.Epix10k2M:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka2M::CalibV1/%s/pixel_mask/'%(self.expname[:3],self.expname,srcStr)        
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
@@ -1505,11 +1507,11 @@ class BaseSmallDataAna_psana(object):
         else:
             plt.subplot(gs[1]).imshow(image_mask,clim=[plotMin,plotMax])
 
-        if  det.dettype == 2:
+        if  det.dettype == DetObjectClass.CsPad:
             mask=mask.reshape(2,185*388).transpose(1,0)
-        elif det.dettype == 1:
+        elif det.dettype == DetObjectClass.CsPad2M:
             mask=mask.reshape(32*185,388)
-        elif det.dettype == 13:
+        elif det.dettype == DetObjectClass.Epix:
             mask=mask.reshape(704,768)
 
         #2x2 save as 71780 lines, 2 entries
@@ -1517,15 +1519,15 @@ class BaseSmallDataAna_psana(object):
         if raw_input("Save to calibdir?\n") in ["y","Y"]:
             mask = (~(mask.astype(bool))).astype(int)
             srcStr=det.source.__str__().replace('Source("DetInfo(','').replace(')")','')
-            if det.dettype==2:
+            if det.dettype==DetObjectClass.CsPad:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad2x2::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)
-            elif det.dettype==2:
+            elif det.dettype==DetObjectClass.CsPad2M:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==13:
+            elif det.dettype==DetObjectClass.Epix:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix100a::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==29:
+            elif det.dettype==DetObjectClass.Epix10k:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==32:
+            elif det.dettype==DetObjectClass.Epix10k2M:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka2M::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
             if not os.path.exists(dirname):
                 os.makedirs(dirname)

--- a/smalldata_tools/BaseSmallDataAna_psana.py
+++ b/smalldata_tools/BaseSmallDataAna_psana.py
@@ -1111,7 +1111,7 @@ class BaseSmallDataAna_psana(object):
         if extMask is None:
             prompt = "Invert [y/n]? (n/no inversion: masked pixels will get rejected)?\n"
         else:
-            prompt = "Does the ext. mask have 0 values for masked pixels [y/n] (n: non-zero pixels are rejected)?\n"
+            prompt = "Does the ext. mask have 0 for masked pixels [y/n] (n: non-zero pixels are rejected)?\n"
         if raw_input(prompt) in ["y","Y"]:
             totmask = (totmask.astype(bool)).astype(int)
         else:

--- a/smalldata_tools/DetObject.py
+++ b/smalldata_tools/DetObject.py
@@ -80,6 +80,34 @@ def DetObject(srcName, env, run, **kwargs):
     #return None
 
 class DetObjectClass(object):
+    # These constants are essentially the inverse of the detector_classes dict above.
+    # Where are these really defined?  PSCalib!  In src/GlobalUtils.py.
+    CsPad2M = 1           # CSPAD
+    CsPad = 2             # CSPAD2X2
+    Pulnix = 5
+    Opal = 6              # OPAL1000
+    Opal2k = 7
+    Opal4k = 8
+    Opal8k = 9
+    Orca = 10
+    Epix = 13
+    AndOr = 15
+    Acqiris = 16
+    Rayonix = 19
+    Fli = 23
+    Jungfrau = 26
+    Zyla = 27
+    ControlsCamera = 28
+    Epix10k = 29
+    Icarus = 30
+    Epix10k2M = 32
+    Epix10k2M_quad = 33
+    Camera = 34           # STREAK?
+    iStar = 36
+    Alvium = 37
+    OceanOptics = 98      # ?
+    Imp = 99              # ?
+    
     def __init__(self,det,env,run, **kwargs):#name=None, common_mode=None, applyMask=0):
         self.det=det
         self._src=det.source
@@ -114,11 +142,11 @@ class DetObjectClass(object):
         if self.ped is not None:
             self.imgShape = self.ped.shape
             try:
-                self.imgShape = self.det.image(self.run, self.ped)
+                self.imgShape = self.det.image(self.run, self.ped).shape
             except:
                 if len(self.ped.shape)>2:
                     try:
-                        self.imgShape = self.det.image(ped[0], self.run)
+                        self.imgShape = self.det.image(ped[0], self.run).shape
                     except:         
                         print('multi dim pedestal & image function does do nothing: multi gain detector.....')
                         self.imgShape=self.ped.shape[1:]
@@ -396,11 +424,11 @@ class OpalObject(CameraObject):
             if self.ped is None or self.ped.shape==(0,0): #this is the case for e.g. the xtcav recorder but can also return with the DAQ. Assume Opal1k for now.
                 #if srcName=='xtcav':
                 #  self.ped = np.zeros([1024,1024])
-                if det.dettype == 6:
+                if det.dettype == DetObjectClass.Opal:
                     self.ped = np.zeros([1024,1024])
                 else:
                     self.ped = None
-        if det.dettype == 6:
+        if det.dettype == DetObjectClass.Opal:
             self.imgShape = self.ped.shape
             if self.x is None:
                 self._get_coords_from_ped()
@@ -1070,7 +1098,7 @@ class Epix10k2MObject(TiledCameraObject):
         self.ped = self.ped.squeeze()
         if self.rms is None or self.rms.shape!=self.ped.shape:
             self.rms=np.ones_like(self.ped)
-        self.imgShape=self.det.image(run, self.ped[0])
+        self.imgShape=self.det.image(run, self.ped[0]).shape
         self._gainSwitching = True                
 
         ##stuff for ghost correction
@@ -1297,11 +1325,11 @@ class RayonixObject(CameraObject):
           self.pixelsize=[170e-3/3840*binning] #needs to change for bigger rayonix.
         try:
           self.ped = np.zeros([rcfg.width(), rcfg.height()])
-          self.imgShape = [rcfg.width(), rcfg.height()]
+          self.imgShape = (rcfg.width(), rcfg.height())
         except: 
           npix = int(170e-3/self.pixelsize[0])
           self.ped = np.zeros([npix, npix])
-          self.imgShape = [npix, npix]
+          self.imgShape = (npix, npix)
         if self.x is None:
             self.x = np.arange(0,self.ped.shape[0]*self.pixelsize[0], self.pixelsize[0])*1e6
             self.y = np.arange(0,self.ped.shape[0]*self.pixelsize[0], self.pixelsize[0])*1e6

--- a/smalldata_tools/SmallDataAna_psana.py
+++ b/smalldata_tools/SmallDataAna_psana.py
@@ -34,7 +34,7 @@ except NameError:
 import smalldata_tools.SmallDataAna as sda
 
 from smalldata_tools.BaseSmallDataAna_psana import BaseSmallDataAna_psana
-from smalldata_tools.DetObject import DetObject
+from smalldata_tools.DetObject import DetObject, DetObjectClass
 from smalldata_tools.SmallDataUtils import getUserData
 from smalldata_tools.utilities import printR
 from smalldata_tools.utilities import addToHdf5
@@ -654,17 +654,17 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
         if dirname == 'calib':
             #detname, img, avImage = self.getAvImage(detname=None)
             srcStr=det.source.__str__().replace('Source("DetInfo(','').replace(')")','')
-            if det.dettype==2:
+            if det.dettype==DetObjectClass.CsPad:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad2x2::CalibV1/%s/'%(self.expname[:3],self.expname,srcStr)
-            elif det.dettype==1:
+            elif det.dettype==DetObjectClass.CsPad2M:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad::CalibV1/%s/'%(self.expname[:3],self.expname,srcStr)        
-            elif det.dettype==13:
+            elif det.dettype==DetObjectClass.Epix:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix100a::CalibV1/%s/'%(self.expname[:3],self.expname,srcStr)
-            elif det.dettype==19:
+            elif det.dettype==DetObjectClass.Rayonix:
                 dirname='/reg/d/psdm/%s/%s/calib/Camera::CalibV1/%s/'%(self.expname[:3],self.expname,srcStr)        
-            elif det.dettype==29:
+            elif det.dettype==DetObjectClass.Epix10k:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka::CalibV1/%s/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==32:
+            elif det.dettype==DetObjectClass.Epix10k2M:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka2M::CalibV1/%s/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
 
         if not os.path.exists(dirname+'pedestals'):
@@ -767,11 +767,11 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
         else:
             plt.subplot(gs[1]).imshow(image_mask,clim=[plotMin,plotMax])
 
-        if  det.dettype == 2:
+        if  det.dettype == DetObjectClass.CsPad:
             mask=mask.reshape(2,185*388).transpose(1,0)
-        elif det.dettype == 1:
+        elif det.dettype == DetObjectClass.CsPad2M:
             mask=mask.reshape(32*185,388)
-        elif det.dettype == 13:
+        elif det.dettype == DetObjectClass.Epix:
             mask=mask.reshape(704,768)
 
         #2x2 save as 71780 lines, 2 entries
@@ -779,15 +779,15 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
         if raw_input("Save to calibdir?\n") in ["y","Y"]:
             mask = (~(mask.astype(bool))).astype(int)
             srcStr=det.source.__str__().replace('Source("DetInfo(','').replace(')")','')
-            if det.dettype==2:
+            if det.dettype==DetObjectClass.CsPad:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad2x2::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)
-            elif det.dettype==2:
+            elif det.dettype==DetObjectClass.CsPad2M:
                 dirname='/reg/d/psdm/%s/%s/calib/CsPad::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==13:
+            elif det.dettype==DetObjectClass.Epix:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix100a::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==29:
+            elif det.dettype==DetObjectClass.Epix10k:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
-            elif det.dettype==32:
+            elif det.dettype==DetObjectClass.Epix10k2M:
                 dirname='/reg/d/psdm/%s/%s/calib/Epix10ka2M::CalibV1/%s/pixel_mask/'%(self.sda.expname[:3],self.sda.expname,srcStr)        
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
@@ -814,7 +814,7 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
         np.seterr(divide='ignore', invalid='ignore')
         hstPed=[]
         hstRms=[]
-        if det.dettype==26 or det.dettype==30:
+        if det.dettype==DetObjectClass.Jungfrau or det.dettype==DetObjectClass.Icarus:
             for ped,frms in zip(pedestals, rms):
                 hstPed.append(np.histogram(ped.flatten(), np.arange(0, pedestals.max()*1.05)))
                 hstRms.append(np.histogram(frms.flatten(), np.arange(0, rms.max()*1.05,0.05)))
@@ -823,13 +823,13 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
             hstRms.append(np.histogram(rms.flatten(), np.arange(0, rms.max()*1.05,0.05)))
 
         if needsGeo:
-            if det.dettype==26:
+            if det.dettype==DetObjectClass.Jungfrau:
                 pedImg = det.image(self.run,pedestals[0])
                 rmsImg = det.image(self.run,rms[0])
                 if pedImg is None and pedestals.shape[1]==1:
                     pedImg = pedestals[0].squeeze()
                     rmsImg = rms[0].squeeze()
-            elif det.dettype==30:
+            elif det.dettype==DetObjectClass.Icarus:
                 pedImg = pedestals[0]; rmsImg = rms[0]
                 for iFrame, pedf, rmsf in zip(itertools.count(), pedestals, rms):
                     if iFrame>0:
@@ -869,7 +869,7 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
         for i in range(len(hstPed)):
             plt.subplot(gsPed[1]).plot(hstPed[i][1][:-1],np.log(hstPed[i][0]),'o')
             plt.subplot(gsPed[3]).plot(hstRms[i][1][:-1],np.log(hstRms[i][0]),'o')
-        if det.dettype==26:
+        if det.dettype==DetObjectClass.Jungfrau:
             im0 = plt.subplot(gsPed[0]).imshow(pedImg,clim=[np.nanpercentile(pedestals[0],1),np.nanpercentile(pedestals[0],99)])
             cbar0 = plt.colorbar(im0)
             im2 = plt.subplot(gsPed[2]).imshow(rmsImg,clim=[np.nanpercentile(rms[0],1),np.nanpercentile(rms[0],99)])
@@ -1264,7 +1264,7 @@ class SmallDataAna_psana(BaseSmallDataAna_psana):
                         addToHdf5(grp, 'ix', det.ix)
                         addToHdf5(grp, 'iy', det.iy)
                 else:
-                    if det.det.dettype==26:
+                    if det.det.dettype==DetObjectClass.Jungfrau:
                         addToHdf5(grp, 'ped', det.det.image(self.run,det.ped[0]))
                         addToHdf5(grp, 'rms', det.det.image(self.run,det.rms[0]))
                         addToHdf5(grp, 'gain', det.det.image(self.run,det.gain[0]))


### PR DESCRIPTION
Allow MakeMask to accept an extMask parameter which, if not None, is the properly-shaped mask to create and apply.

This requires knowing the shape of the raw data, so the rawShape property was added to the detector object.  This is initialized by the _getRawShape method which is called after any data retrieval.
