### PR TITLE
Improvements to `PedestalPlot`'s elog posting functionality and minor change to DetObject

### DIFF
--- a/smalldata_tools/DetObject.py
+++ b/smalldata_tools/DetObject.py
@@ -927,7 +927,6 @@ class Epix10kObject(TiledCameraObject):
         epixCfg = env.configStore().get(psana.Epix.Config10kaV1, det.source)              
         if epixCfg is None:
             epixCfg = env.configStore().get(psana.Epix.Config10kaV2, det.source)    
-        self.trbit = []
         self.pixelGain=[]
         self.nomGain=[1.,3.,100.,100.,3.,100.] #H,M,L,(HL auto), (ML auto - 2 values)
         #asicList=[0,3,1,2]
@@ -938,7 +937,7 @@ class Epix10kObject(TiledCameraObject):
         trbits=[]
         for ia in range(epixCfg.asics_shape()[0]):
             trbits.append(epixCfg.asics(ia).trbit())
-        self.trbit = trbits
+        self.trbit = np.array(trbits)
 
         cfgShape=epixCfg.asicPixelConfigArray().shape
         cfgReshape=epixCfg.asicPixelConfigArray().reshape(int(cfgShape[0]/2), cfgShape[1]*2,order='F')
@@ -1118,6 +1117,7 @@ class Epix10k2MObject(TiledCameraObject):
             pixelGain=pixelGain.reshape(cfgShape,order='F')
             self.pixelGain.append(pixelGain)
         self.pixelGain=np.array(self.pixelGain)
+        self.trbit = np.array(self.trbit)
         self.gainSetting = 0
         if self.pixelGain.mean()==0:
             if self.trbit.mean()==1:

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -193,7 +193,7 @@ def getElogBasicAuth(exp: str) -> HTTPBasicAuth:
 def getRunsWithTag(
         exp: str,
         tag: str,
-        http_auth: Optional[HTTPBasicAuth]=None
+        http_auth: Optional[HTTPBasicAuth] = None
 ) -> list:
     """Return a list of runs tagged with a specific `tag`.
 
@@ -227,7 +227,7 @@ def postElogMsg(
         title: Optional[str] = "",
         files: list = []
 ) -> None:
-    """Post a new message to the eLog.
+    """Post a new message to the eLog. Adapted from `elog` package.
 
     Parameters
     ----------
@@ -268,9 +268,9 @@ def postElogMsg(
 
     http_auth: HTTPBasicAuth = getElogBasicAuth(exp)
     base_url: str = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
-    post_url = f"{base_url}/{exp}/ws/new_elog_entry"
+    post_url: str = f"{base_url}/{exp}/ws/new_elog_entry"
 
-    params = {'url': post_url, 'data': post, 'auth': http_auth}
+    params: dict = {'url': post_url, 'data': post, 'auth': http_auth}
     if post_files:
         params.update({'files': post_files})
 
@@ -726,7 +726,7 @@ def plotPedestals(expname='mfxc00118', run=364, nosave_elog=False, make_ped_imgs
         print('runTableData:')
         print(runTableData)
 
-    postBadPixMsg(detectors=det_names, exp=expname, run=run)
+    postBadPixMsg(detectors=sorted(det_names, reverse=True), exp=expname, run=run)
     if not nosave_elog:
         elogDir = Path(SIT_PSDM_DATA) / expname[:3] / expname / f"stats/summary/Pedestals/Pedestals_Run{runnum:03d}"
 

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -328,7 +328,14 @@ def postBadPixMsg(
                     stat_dict: dict = statusStats(det_name, request_run=dr)
                     bad_pix.append(stat_dict['total_masked'])
                 except TypeError as err:
-                    # `statusStats` throws TypeError if detector not in run
+                    # `statusStats` may throw TypeError if detector not in run
+                    logger.debug(
+                        f"Is {det_name} not present in DARK run {dr}?\n"
+                        f"ERROR: {err}"
+                    )
+                    bad_pix.append(0)
+                except KeyError as err:
+                    # `statusStats` may throw KeyError if detector not in run
                     logger.debug(
                         f"Is {det_name} not present in DARK run {dr}?\n"
                         f"ERROR: {err}"

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -309,7 +309,6 @@ def postBadPixMsg(
     if dark_runs:
         dark_runs = [dr for dr in dark_runs if dr <= run]
 
-        bad_pix: list = []
         table_header: str = (
             "<thead><tr><th colspan=\"3\">"
             f"<center>{title}</center>"
@@ -323,9 +322,18 @@ def postBadPixMsg(
         )
 
         for det_name in detectors:
+            bad_pix: list = []
             for dr in dark_runs:
-                stat_dict: dict = statusStats(det_name, request_run=dr)
-                bad_pix.append(stat_dict['total_masked'])
+                try:
+                    stat_dict: dict = statusStats(det_name, request_run=dr)
+                    bad_pix.append(stat_dict['total_masked'])
+                except TypeError as err:
+                    # `statusStats` throws TypeError if detector not in run
+                    logger.debug(
+                        f"Is {det_name} not present in DARK run {dr}?\n"
+                        f"ERROR: {err}"
+                    )
+                    bad_pix.append(0)
 
             # Report current DARK run bad pix and the delta vs previous DARK run
             curr_bad_pix = bad_pix[-1]


### PR DESCRIPTION
Change Log
------------------
- Sort the detector names in descending alphabetical order prior to passing the list to `postBadPixMsg`
- Catch a number of errors which if uncaught cause the `PedestalPlot` jobs to fail. These seem to occur if a detector is added in later runs. The script checks for all detectors present in the current run in all PREVIOUS runs and if one was added later, it may not be present. An example of this can be seen in `mecl1002021` (check the logs under `Workflow > Control` for `PedestalPlot` submissions).
  - Catches `TypeError` and presents a debug level message.
  - Catches `KeyError` and presents a debug level message.
  - If the detector is not present it will append a `0` for the number of bad pixels for that detector in that particular run.
- Convert `self.trbit` to a NumPy array to avoid taking mean of list in fallback code of `DetObject.py`