### PR TITLE
fix for live mode failure

### DIFF
--- a/producers/smd_producer.py
+++ b/producers/smd_producer.py
@@ -473,6 +473,8 @@ if useFFB:
         ds_name += ':live'
         if not onS3DF:
             ds_name += f':dir=/cds/data/drpsrcf/{exp[0:3]}/{exp}/xtc'
+        psana.setOption('PSXtcInput.XtcInputModule.liveTimeout', 300)
+        # bigger timeout so that the live mode does not fail
 
 logger.debug(f'DataSource name: {ds_name}')
 try:


### PR DESCRIPTION
Increase live mode timeout, so that the live mode stops failing in the ARP