### PR TITLE
Bug/ttfix ttraw

### DIFF
--- a/producers/smd_producer.py
+++ b/producers/smd_producer.py
@@ -223,6 +223,7 @@ print(f'\n{fpathup}')
 from smalldata_tools.utilities import printMsg, checkDet
 from smalldata_tools.SmallDataUtils import setParameter, getUserData, getUserEnvData
 from smalldata_tools.SmallDataUtils import defaultDetectors, detData, detOnceData
+from smalldata_tools.SmallDataDefaultDetector import ttRawDetector
 from smalldata_tools.SmallDataDefaultDetector import epicsDetector, eorbitsDetector
 from smalldata_tools.SmallDataDefaultDetector import bmmonDetector, ipmDetector
 from smalldata_tools.SmallDataDefaultDetector import encoderDetector, adcDetector
@@ -335,6 +336,9 @@ parser.add_argument("--noarch",
                     help="dont use archiver data", 
                     action='store_true',
                     default=False)
+parser.add_argument("--ttRaw",
+                    help="add timetool projections",
+                    action='store_true')
 args = parser.parse_args()
 logger.debug('Args to be used for small data run: {0}'.format(args))
 
@@ -499,6 +503,14 @@ default_dets = defaultDetectors(hutch.lower(), env=ds.env())
 if args.xtcav and not args.norecorder:
     #default_dets.append(xtcavDetector('xtcav','xtcav',method='COM'))
     default_dets.append(xtcavDetector('xtcav','xtcav'))
+#adding raw timetool traces:
+if args.ttRaw:
+    try:
+        ttRawDet = ttRawDetector(env=ds.env())
+        ttRawDet.setPars({'beamOff':[-137], 'refitData': False})
+        default_dets.append(ttRawDet)
+    except:
+        pass
 
 #
 # add stuff here to save all EPICS PVs.

--- a/setup_scripts/sdf_setup.sh
+++ b/setup_scripts/sdf_setup.sh
@@ -27,11 +27,11 @@ do
 		usage
 		exit
 		;;
-    -e)
+    -e|--experiment)
         EXP="$2"
         shift 2
         ;;
-    -q)
+    -q|--queue)
         QUEUE="$2"
         shift 2
         ;;

--- a/smalldata_tools/SmallDataDefaultDetector.py
+++ b/smalldata_tools/SmallDataDefaultDetector.py
@@ -441,8 +441,8 @@ class ttDetector(defaultDetector):
             #pixel 0 is special:
             #it indicates that fit was not attempted/unsuccessful
             if ttOrg == 0:
-                dl['ttCorr'] = 0
-        return dl
+                dl['ttCorr'] = 0.
+            return dl
 
 class damageDetector(defaultDetector):
     def __init__(self, name='damage'):

--- a/smalldata_tools/SmallDataDefaultDetector.py
+++ b/smalldata_tools/SmallDataDefaultDetector.py
@@ -396,6 +396,7 @@ class ttDetector(defaultDetector):
                     print('could not find timetool EPICS PV %s in data'%pv)
         self.ttCalib=None
         if env is not None:
+            ttCfg = None
             for cfgKey in env.configStore().keys():
                 if cfgKey.type() == psana.TimeTool.ConfigV2:
                     ttCfg = env.configStore().get(psana.TimeTool.ConfigV2, cfgKey.src())


### PR DESCRIPTION
two small changes:
- fix saving of ttCorr values when many events are broken (set value to 0. instead of 0. If using 0, the hdf5-saving will convert the few floats to ints when a rank ends up w/o any floats)
- add command line option to save timetool traces (assuming we project as typically done for the spectral timetool). This also works for the Alvium as a timetool.