### PR TITLE
make job fail for real if xtc files are not found

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -418,7 +418,7 @@ if hostname.find('sdf')>=0:
                 print(f"Waited {str(n_wait*10)}s, still no files available. " \
                        "Giving up, please check dss nodes and data movers. " \
                        "Exiting now.")
-                sys.exit()
+                raise RuntimeError("Waited {str(n_wait*10)}s, still no files available. Giving up.")
             xtc_files = get_xtc_files(PSDM_BASE, exp, run)
             nFiles = len(xtc_files)
             if nFiles == 0:
@@ -432,7 +432,7 @@ if hostname.find('sdf')>=0:
     xtc_files = get_xtc_files(PSDM_BASE, exp, run)
     if len(xtc_files)==0:
         print(f'We have no xtc files for run {run} in {exp} in the offline system. Exit now.')
-        sys.exit()
+        raise RuntimeError(f'We have no xtc files for run {run} in {exp} in the offline system.')
 
 elif hostname.find('drp')>=0:
     nFiles=0

--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -415,9 +415,6 @@ if hostname.find('sdf')>=0:
         waitFilesStart=datetime.now()
         while nFiles == 0:
             if n_wait > max_wait:
-                print(f"Waited {str(n_wait*10)}s, still no files available. " \
-                       "Giving up, please check dss nodes and data movers. " \
-                       "Exiting now.")
                 raise RuntimeError("Waited {str(n_wait*10)}s, still no files available. Giving up.")
             xtc_files = get_xtc_files(PSDM_BASE, exp, run)
             nFiles = len(xtc_files)
@@ -431,7 +428,6 @@ if hostname.find('sdf')>=0:
 
     xtc_files = get_xtc_files(PSDM_BASE, exp, run)
     if len(xtc_files)==0:
-        print(f'We have no xtc files for run {run} in {exp} in the offline system. Exit now.')
         raise RuntimeError(f'We have no xtc files for run {run} in {exp} in the offline system.')
 
 elif hostname.find('drp')>=0:

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -301,7 +301,7 @@ if hostname.find('sdf')>=0:
                 print(f"Waited {str(n_wait*10)}s, still no files available. " \
                        "Giving up, please check dss nodes and data movers. " \
                        "Exiting now.")
-                sys.exit()
+                raise RuntimeError("Waited {str(n_wait*10)}s, still no files available. Giving up.")
             xtc_files = get_xtc_files(PSDM_BASE, exp, run)
             nFiles = len(xtc_files)
             if nFiles == 0:
@@ -315,7 +315,7 @@ if hostname.find('sdf')>=0:
     xtc_files = get_xtc_files(PSDM_BASE, exp, run)
     if len(xtc_files)==0:
         print(f'We have no xtc files for run {run} in {exp} in the offline system. Exit now.')
-        sys.exit()
+        raise RuntimeError(f'We have no xtc files for run {run} in {exp} in the offline system.')
 
 else:
     logger.warning('On an unknow system, things may get weird.')

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -298,9 +298,6 @@ if hostname.find('sdf')>=0:
         waitFilesStart=datetime.now()
         while nFiles == 0:
             if n_wait > max_wait:
-                print(f"Waited {str(n_wait*10)}s, still no files available. " \
-                       "Giving up, please check dss nodes and data movers. " \
-                       "Exiting now.")
                 raise RuntimeError("Waited {str(n_wait*10)}s, still no files available. Giving up.")
             xtc_files = get_xtc_files(PSDM_BASE, exp, run)
             nFiles = len(xtc_files)
@@ -314,7 +311,6 @@ if hostname.find('sdf')>=0:
 
     xtc_files = get_xtc_files(PSDM_BASE, exp, run)
     if len(xtc_files)==0:
-        print(f'We have no xtc files for run {run} in {exp} in the offline system. Exit now.')
         raise RuntimeError(f'We have no xtc files for run {run} in {exp} in the offline system.')
 
 else:


### PR DESCRIPTION
sys.exit does not properly kill all cores. Raising an exception will.