### PR TITLE
BUG Fix LCLS1 Producer droplet parameter parsing

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -153,12 +153,12 @@ def define_dets(run):
                 det.addFunc(photonFunc(**phot[detname]))
             # Droplet algo
             if detname in drop:
-                if nData in drop:
-                    nData = drop.pop('nData')
+                if 'nData' in drop[detname]:
+                    nData = drop[detname].pop('nData')
                 else:
                     nData = None
                 func = dropletFunc(**drop[detname])
-                func.addFunc(roi.sparsifyFunc(nData=nData))
+                func.addFunc(sparsifyFunc(nData=nData))
                 det.addFunc(func)
             # Droplet to photons
             if detname in drop2phot:


### PR DESCRIPTION
This PR fixes a minor bug in the producer when extracting droplet parameters.

Checklist
-------------
- [x] Bug fix for pulling `nData` from droplet parameters, and adding a `sparsifyFunc` in the LCLS1 producer when using the droplet algorithm.