### PR TITLE
ENH Include run number in eLog posts

### DIFF
--- a/summaries/BeamlineSummaryPlots_mfx.py
+++ b/summaries/BeamlineSummaryPlots_mfx.py
@@ -10,6 +10,7 @@ import socket
 import requests
 from requests.auth import HTTPBasicAuth
 from typing import Optional, Tuple, Dict, Union, List
+import mimetypes
 
 import h5py
 import numpy as np
@@ -67,6 +68,7 @@ def postElogMsg(
     exp: str,
     msg: str,
     *,
+    run: Optional[Union[int,str]] = None,
     tag: Optional[str] = "",
     title: Optional[str] = "",
     files: list = [],
@@ -77,6 +79,7 @@ def postElogMsg(
     ----------
     exp (str) Experiment name.
     msg (str) Body of the eLog post.
+    run (int | str) Optional. The run number to associate to the post.
     tag (str) Optional. A tag to include for the post.
     title (str) Optional. A title for the eLog post.
     files (list) Optional. Either a list of paths (str) to files (figures) to
@@ -109,6 +112,8 @@ def postElogMsg(
         post["log_tags"] = tag
     if title:
         post["log_title"] = title
+    if run:
+        post["run_num"] = int(run)
 
     http_auth: HTTPBasicAuth = getElogBasicAuth(exp)
     base_url: str = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
@@ -125,6 +130,7 @@ def postElogMsg(
 
     if not resp.json()["success"]:
         logger.debug(f"Error when posting to eLog: {resp.json()['error_msg']}")
+
 
 
 def postDetectorDamageMsg(

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -15,7 +15,7 @@ import requests
 from pathlib import Path
 from requests.auth import HTTPBasicAuth
 import socket
-from typing import Optional
+from typing import Optional, Union
 import mimetypes
 
 try:
@@ -278,6 +278,7 @@ def postElogMsg(
     exp: str,
     msg: str,
     *,
+    run: Optional[Union[int,str]] = None,
     tag: Optional[str] = "",
     title: Optional[str] = "",
     files: list = [],
@@ -288,6 +289,7 @@ def postElogMsg(
     ----------
     exp (str) Experiment name.
     msg (str) Body of the eLog post.
+    run (int | str) Optional. The run number to associate to the post.
     tag (str) Optional. A tag to include for the post.
     title (str) Optional. A title for the eLog post.
     files (list) Optional. Either a list of paths (str) to files (figures) to
@@ -320,6 +322,8 @@ def postElogMsg(
         post["log_tags"] = tag
     if title:
         post["log_title"] = title
+    if run:
+        post["run_num"] = int(run)
 
     http_auth: HTTPBasicAuth = getElogBasicAuth(exp)
     base_url: str = "https://pswww.slac.stanford.edu/ws-auth/lgbk/lgbk"
@@ -410,7 +414,7 @@ def postBadPixMsg(
         msg: str = "No DARK runs or cannot communicate with eLog."
         logger.debug(msg)
 
-    postElogMsg(exp=exp, msg=msg, tag=tag, title=title)
+    postElogMsg(exp=exp, msg=msg, run=run, tag=tag, title=title)
 
 
 def ped_rms_histograms(nCycles, peds, noise, diff, alias=""):


### PR DESCRIPTION
This PR adds the option to associate a run number to an eLog post. This is done for the `SUMMARY_BAD_PIX` posts from the pedestal plots.

Checklist
-------------
- [x] Add option to include run number for eLog posts.
- [x] Include run number for `SUMMARY_BAD_PIX` posts

Screenshots
------------------
Previously, the bad pixel posts looked like this:
![image](https://github.com/user-attachments/assets/4f185a24-9025-4386-8423-c88e1b3de600)

**After this PR, they will include the run number**
![image](https://github.com/user-attachments/assets/d116b5af-b86d-453d-8a14-7d4d891c14dd)
