### PR TITLE
ENH First draft of prev/next buttons on run summaries

### DIFF
--- a/summaries/BeamlineSummaryPlots_cxi.py
+++ b/summaries/BeamlineSummaryPlots_cxi.py
@@ -424,26 +424,18 @@ from pathlib import Path
 
 SIT_PSDM_DATA = Path(os.environ.get("SIT_PSDM_DATA"))
 runnum = int(args.run)
-elogDir = (
-    Path(SIT_PSDM_DATA)
-    / expname[:3]
-    / expname
-    / f"stats/summary/BeamlineSummary/BeamlineSummary_Run{runnum:03d}"
-)
+
 if save_elog:
-    import os
+    from summaries.summary_utils import prepareHtmlReport
 
-    if not os.path.isdir(elogDir):
-        os.makedirs(elogDir)
-    print("Made Directory to save data:", elogDir)
-    # gspec.save(('%s/report.html'%elogDir))
-    tabs.save(("%s/report.html" % elogDir))
+    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
+    prepareHtmlReport(tabs, expname, run, pageTitleFormat)
 
-if int(os.environ.get("RUN_NUM", "-1")) > 0:
-    requests.post(
-        os.environ["JID_UPDATE_COUNTERS"],
-        json=[{"key": "<b>BeamlineSummary Plots </b>", "value": "Posted"}],
-    )
+    if int(os.environ.get("RUN_NUM", "-1")) > 0:
+        requests.post(
+            os.environ["JID_UPDATE_COUNTERS"],
+            json=[{"key": "<b>BeamlineSummary Plots </b>", "value": "Posted"}],
+        )
 
 if args.postStats:
     print("posting to the run tables - ipm values.")

--- a/summaries/BeamlineSummaryPlots_mfx.py
+++ b/summaries/BeamlineSummaryPlots_mfx.py
@@ -68,7 +68,7 @@ def postElogMsg(
     exp: str,
     msg: str,
     *,
-    run: Optional[Union[int,str]] = None,
+    run: Optional[Union[int, str]] = None,
     tag: Optional[str] = "",
     title: Optional[str] = "",
     files: list = [],
@@ -130,7 +130,6 @@ def postElogMsg(
 
     if not resp.json()["success"]:
         logger.debug(f"Error when posting to eLog: {resp.json()['error_msg']}")
-
 
 
 def postDetectorDamageMsg(
@@ -825,15 +824,11 @@ if int(os.environ.get("RUN_NUM", "-1")) > 0:
         json=[{"key": "<b>BeamlineSummary Plots </b>", "value": "Done"}],
     )
 
-elogDir = f"/sdf/data/lcls/ds/{expname[:3]}/{expname}/stats/summary/BeamlineSummary/BeamlineSummary_Run{run:04d}"
-
 if save_elog:
-    import os
+    from summaries.summary_utils import prepareHtmlReport
 
-    if not os.path.isdir(elogDir):
-        os.makedirs(elogDir)
-    print("Made Directory to save data:", elogDir)
-    tabs.save(("%s/report.html" % elogDir))
+    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
+    prepareHtmlReport(tabs, expname, run, pageTitleFormat)
     postDetectorDamageMsg(
         detectors=detNames,
         exp=expname,

--- a/summaries/BeamlineSummaryPlots_rix.py
+++ b/summaries/BeamlineSummaryPlots_rix.py
@@ -356,27 +356,17 @@ if ttpos is not None:
 ## save the html file
 ##################################
 
-elogDir = (
-    Path(SIT_PSDM_DATA)
-    / expname[:3]
-    / expname
-    / f"stats/summary/BeamlineSummary/BeamlineSummary_Run{runnum:03d}"
-)
-
 if save_elog:
-    import os
+    from summaries.summary_utils import prepareHtmlReport
 
-    if not os.path.isdir(elogDir):
-        os.makedirs(elogDir)
-    print("Made Directory to save data:", elogDir)
-    # gspec.save(('%s/report.html'%elogDir))
-    tabs.save(("%s/report.html" % elogDir))
+    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
+    prepareHtmlReport(tabs, expname, run, pageTitleFormat)
 
-if int(os.environ.get("RUN_NUM", "-1")) > 0:
-    requests.post(
-        os.environ["JID_UPDATE_COUNTERS"],
-        json=[{"key": "<b>BeamlineSummary Plots </b>", "value": "Posted"}],
-    )
+    if int(os.environ.get("RUN_NUM", "-1")) > 0:
+        requests.post(
+            os.environ["JID_UPDATE_COUNTERS"],
+            json=[{"key": "<b>BeamlineSummary Plots </b>", "value": "Posted"}],
+        )
 
 if args.postStats:
     print("posting to the run tables - ipm values.")

--- a/summaries/BeamlineSummaryPlots_xcs.py
+++ b/summaries/BeamlineSummaryPlots_xcs.py
@@ -434,13 +434,10 @@ SIT_PSDM_DATA = os.getenv("SIT_PSDM_DATA")
 elogDir = f"{SIT_PSDM_DATA}/{expname[:3]}/{expname}/stats/summary/BeamlineSummary/BeamlineSummary_Run{run:04d}"
 
 if save_elog:
-    import os
+    from summaries.summary_utils import prepareHtmlReport
 
-    if not os.path.isdir(elogDir):
-        os.makedirs(elogDir)
-    print("Made Directory to save data:", elogDir)
-    # gspec.save(('%s/report.html'%elogDir))
-    tabs.save(("%s/report.html" % elogDir))
+    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
+    prepareHtmlReport(tabs, expname, run, pageTitleFormat)
 
     if int(os.environ.get("RUN_NUM", "-1")) > 0:
         requests.post(

--- a/summaries/BeamlineSummaryPlots_xpp.py
+++ b/summaries/BeamlineSummaryPlots_xpp.py
@@ -396,19 +396,10 @@ nOff = ana.getFilter(
 ##################################
 
 if save_elog:
-    elogDir = (
-        Path(SIT_PSDM_DATA)
-        / expname[:3]
-        / expname
-        / f"stats/summary/BeamlineSummary/BeamlineSummary_Run{run:03d}"
-    )
-    import os
+    from summaries.summary_utils import prepareHtmlReport
 
-    if not os.path.isdir(elogDir):
-        os.makedirs(elogDir)
-    print("Made Directory to save data:", elogDir)
-    # gspec.save(('%s/report.html'%elogDir))
-    tabs.save(("%s/report.html" % elogDir))
+    pageTitleFormat = "BeamlineSummary/BeamlineSummary_Run{run:04d}"
+    prepareHtmlReport(tabs, expname, run, pageTitleFormat)
 
 if int(os.environ.get("RUN_NUM", "-1")) > 0:
     requests.post(

--- a/summaries/PedestalPlot.py
+++ b/summaries/PedestalPlot.py
@@ -278,7 +278,7 @@ def postElogMsg(
     exp: str,
     msg: str,
     *,
-    run: Optional[Union[int,str]] = None,
+    run: Optional[Union[int, str]] = None,
     tag: Optional[str] = "",
     title: Optional[str] = "",
     files: list = [],

--- a/summaries/summary_utils.py
+++ b/summaries/summary_utils.py
@@ -1,6 +1,25 @@
+"""Includes functions for creating summary plots.
+
+Functions
+---------
+getFormattedPageTitle(experiment: str, run: int, pageTitle: str) -> str: Format a
+    an uncompiled summary page title to include experiment/run etc.
+
+getLinkDiv(experiment: str, run: int, pageTitle: str) -> str: Update the navigation
+    link portion (LINK_DIV) with the correct links.
+
+updateSymLinks(fullPath: str, run: int) -> None: Update the symbolic links pointing
+    to the most recent and first run summary report HTML.
+
+prepareHtmlReport(tabs: pn.Tabs, experiment: str, run: int, pageTitle: str) -> None:
+    Prepare the full HTML report including navigation, update symbolic links and write
+    the report file.
+"""
+
 import io
 import os
 import re
+from typing import Optional
 
 import panel as pn
 
@@ -41,14 +60,34 @@ LINK_STYLE: str = """
 
 LINK_DIV: str = """
     <div style:"width: 100%; border:1px solid red">
-      <a href="../{prevPage}/report.html" style="margin-right:150px"> Previous </a>
+      <a href="{currPage}/../.first.html" style="margin-right:150px"> First </a>
 
-      <a href="../{nextPage}/report.html"> Next </a>
+      <a href="{prevPage}/report.html" style="margin-right:150px"> Previous </a>
+
+      <a href="{nextPage}/report.html" style="margin-right:150px"> Next </a>
+
+      <a href="{currPage}/../.latest.html"> Latest </a>
     </div>
+    <br><br>
 """
 
 
 def getFormattedPageTitle(experiment: str, run: int, pageTitle: str) -> str:
+    """Apply formatting to a run summary page title.
+
+    Parameters
+    ----------
+    experiment (str) Name of the experiment.
+
+    run (int) Current run.
+
+    pageTitle (str) Summary page title with format specifiers un-compiled.
+        E.g. BeamlineSummary/BeamlineSummary_Run{run:04d}.
+
+    Returns
+    -------
+    formattTitle (str) Page title with formatting applied.
+    """
     runPtn: str = "{run.*}"
     formattedTitle: str = re.sub(
         runPtn, lambda match: match[0].format(run=run), pageTitle
@@ -69,17 +108,87 @@ def getFormattedPageTitle(experiment: str, run: int, pageTitle: str) -> str:
 
 
 def getLinkDiv(experiment: str, run: int, pageTitle: str) -> str:
-    prevPage: str = getFormattedPageTitle(experiment, run - 1, pageTitle)
-    nextPage: str = getFormattedPageTitle(experiment, run + 1, pageTitle)
-    if "/" in prevPage:
-        # HANDLE pageTitle formats of type: Summary/Summary_RUN
-        prevPage = prevPage.split("/")[-1]
-        nextPage = nextPage.split("/")[-1]
+    """For an experiment, run and summary page title, update button links.
 
-    return LINK_DIV.format(prevPage=prevPage, nextPage=nextPage)
+    Parameters
+    ----------
+    experiment (str) Experiment name.
+
+    run (int) Run number.
+
+    pageTitle (str) Summary page title with format specifiers un-compiled.
+        E.g. BeamlineSummary/BeamlineSummary_Run{run:04d}.
+
+    Returns
+    -------
+    link_div (str) Formatted HTML for the <div> containing navigation links.
+    """
+    hutch: str = experiment[:3].upper()
+    URLBase: str = "https://pswww.slac.stanford.edu/experiment_results/"
+    expBase: str = f"{URLBase}/{hutch}/{experiment}"
+
+    prevPageTitle: str = getFormattedPageTitle(experiment, run - 1, pageTitle)
+    currPageTitle: str = getFormattedPageTitle(experiment, run, pageTitle)
+    nextPageTitle: str = getFormattedPageTitle(experiment, run + 1, pageTitle)
+    prevPage: str = f"{expBase}/{prevPageTitle}"
+    currPage: str = f"{expBase}/{currPageTitle}"
+    nextPage: str = f"{expBase}/{nextPageTitle}"
+
+    return LINK_DIV.format(prevPage=prevPage, currPage=currPage, nextPage=nextPage)
+
+
+def updateSymLinks(fullPath: str, run: int) -> None:
+    """Update symbolic links pointing to most recent and first run summary.
+
+    WARNING: This function only works for summaries that are alone in a parent
+    folder. Either they are nested, for example, like Summary/Summary_Run0000,
+    OR, they are at the top level of the experiment's stats/summary directory
+    but no other types of summary plots have been created.
+
+    This function also assumes the ONLY NUMBER in the page titles is the RUN
+    NUMBER.
+
+    Parameters
+    ----------
+    fullPath (str) Full path to the CURRENT run summary being processed.
+
+    run (int) The current run being processed.
+    """
+    currentSummaries: list[str] = [
+        d for d in os.listdir(f"{fullPath}/..") if d[0] != "."
+    ]
+    currentRuns: list[int] = []
+    for summ in currentSummaries:
+        res: Optional[re.Match] = re.search(r"[0-9]+", summ)
+        if res is not None:
+            currentRuns.append(int(res[0]))
+
+    currentRuns.sort()
+    if len(currentRuns) > 0:
+        if run <= currentRuns[0]:
+            if os.path.exists(f"{fullPath}/../.first.html"):
+                os.remove(f"{fullPath}/../.first.html")
+            os.symlink(f"{fullPath}/report.html", f"{fullPath}/../.first.html")
+        if run >= currentRuns[-1]:
+            if os.path.exists(f"{fullPath}/../.latest.html"):
+                os.remove(f"{fullPath}/../.latest.html")
+            os.symlink(f"{fullPath}/report.html", f"{fullPath}/../.latest.html")
 
 
 def prepareHtmlReport(tabs: pn.Tabs, experiment: str, run: int, pageTitle: str) -> None:
+    """Given run summary plots prepare an HTML report including navigation links.
+
+    Parameters
+    ----------
+    tabs (pn.Tabs) Tabular run summary plots to include in HTML report.
+
+    experiment (str) Experiment name.
+
+    run (int) Run number.
+
+    pageTitle (str) Summary page title with format specifiers un-compiled.
+        E.g. BeamlineSummary/BeamlineSummary_Run{run:04d}.
+    """
     f: io.BytesIO = io.BytesIO()
     tabs.save(f)
     f.seek(0)
@@ -103,3 +212,6 @@ def prepareHtmlReport(tabs: pn.Tabs, experiment: str, run: int, pageTitle: str) 
 
     with open(f"{fullPath}/report.html", "w") as report:
         report.write(htmlOut)
+
+    # Call updateSymLinks after making new summary page so calculation works
+    updateSymLinks(fullPath, run)

--- a/summaries/summary_utils.py
+++ b/summaries/summary_utils.py
@@ -1,0 +1,105 @@
+import io
+import os
+import re
+
+import panel as pn
+
+
+LINK_STYLE: str = """
+    <style>
+      a:link, a:visited {
+        background-color: #FF0033;
+        border-radius: 8px;
+        border-style: none;
+        box-sizing: border-box;
+        color: #FFFFFF;
+        cursor: pointer;
+        display: inline-block;
+        font-family: "Haas Grot Text R Web", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        font-weight: 500;
+        height: 40px;
+        line-height: 20px;
+        list-style: none;
+        margin: 0;
+        outline: none;
+        padding: 10px 16px;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        transition: color 100ms;
+        vertical-align: baseline;
+        user-select: none;
+        -webkit-user-select: none;
+        touch-action: manipulation;
+      }
+      a:hover, a:active {
+        background-color: #F082AC;
+      }
+    </style>
+"""
+
+LINK_DIV: str = """
+    <div style:"width: 100%; border:1px solid red">
+      <a href="../{prevPage}/report.html" style="margin-right:150px"> Previous </a>
+
+      <a href="../{nextPage}/report.html"> Next </a>
+    </div>
+"""
+
+
+def getFormattedPageTitle(experiment: str, run: int, pageTitle: str) -> str:
+    runPtn: str = "{run.*}"
+    formattedTitle: str = re.sub(
+        runPtn, lambda match: match[0].format(run=run), pageTitle
+    )
+
+    hutch: str = experiment[:3]
+    hutchPtn: str = "{hutch}"
+    formattedTitle = re.sub(
+        hutchPtn, lambda match: match[0].format(hutch=hutch), formattedTitle
+    )
+
+    expmtPtn: str = "{experiment}"
+    formattedTitle = re.sub(
+        expmtPtn, lambda match: match[0].format(experiment=experiment), formattedTitle
+    )
+
+    return formattedTitle
+
+
+def getLinkDiv(experiment: str, run: int, pageTitle: str) -> str:
+    prevPage: str = getFormattedPageTitle(experiment, run - 1, pageTitle)
+    nextPage: str = getFormattedPageTitle(experiment, run + 1, pageTitle)
+    if "/" in prevPage:
+        # HANDLE pageTitle formats of type: Summary/Summary_RUN
+        prevPage = prevPage.split("/")[-1]
+        nextPage = nextPage.split("/")[-1]
+
+    return LINK_DIV.format(prevPage=prevPage, nextPage=nextPage)
+
+
+def prepareHtmlReport(tabs: pn.Tabs, experiment: str, run: int, pageTitle: str) -> None:
+    f: io.BytesIO = io.BytesIO()
+    tabs.save(f)
+    f.seek(0)
+    tabsHtmlBytes: bytes = f.read()
+
+    htmlOut: str = ""
+    for line in tabsHtmlBytes.decode("UTF-8").split("\n"):
+        htmlOut += f"{line}\n"
+        if "<title>" in line:
+            htmlOut += LINK_STYLE
+        elif "<body>" in line:
+            htmlOut += getLinkDiv(experiment, run, pageTitle)
+
+    hutch: str = experiment[:3]
+    elogBaseDir: str = f"/sdf/data/lcls/ds/{hutch}/{experiment}/stats/summary"
+    fullPath: str = f"{elogBaseDir}/{getFormattedPageTitle(experiment, run, pageTitle)}"
+
+    if not os.path.isdir(fullPath):
+        os.makedirs(fullPath)
+        print("Made Directory to save data:", fullPath)
+
+    with open(f"{fullPath}/report.html", "w") as report:
+        report.write(htmlOut)


### PR DESCRIPTION
This PR adds previous/next buttons to the top of the `BeamlineSummaryPlots` as a small QOL improvement for cycling between runs.

Checklist
-------------
- [x] `summaries/summary_utils.py` holds the new report preparation code. Can be used for shared code in the future.
- [x] Modify `summaries/BeamlineSummaryPlots_$HUTCH.py` to use the new code which includes buttons.

Screenshots
------------------
Buttons for navigating forward/back and to the most recent/first run summary that currently exists.
![image](https://github.com/user-attachments/assets/23d789dc-a338-4d43-978e-4627da69f2a6)
