### PR TITLE
Enh/mfxl1045123

### DIFF
--- a/arp_scripts/submit_smd.sh
+++ b/arp_scripts/submit_smd.sh
@@ -240,7 +240,7 @@ if [ -v LOGDIR ]; then
 fi
 
 #SBATCH_ARGS="-p $QUEUE --ntasks-per-node $TASKS_PER_NODE --ntasks $CORES -o $LOGFILE --exclusive"
-SBATCH_ARGS="-p $QUEUE --nodes 0-$MAX_NODES --ntasks $CORES -o $LOGFILE"
+SBATCH_ARGS="-p $QUEUE --nodes 0-$MAX_NODES --ntasks $CORES --use-min-nodes -o $LOGFILE"
 MPI_CMD="mpirun -np $CORES python -u -m mpi4py.run ${ABS_PATH}/${PYTHONEXE} $*"
 
 

--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -40,10 +40,11 @@ def getROIs(run):
     ret_dict = {}
     if run>0:
         roi_dict = {}
-        roi_dict['ROIs'] = [ [[1,2], [157,487], [294,598]] ] # can define more than one ROI
+        roi_dict['name'] = 'ROI_0'
+        roi_dict['ROI'] = [[1,2], [157,487], [294,598]]
         roi_dict['writeArea'] = True
         roi_dict['thresADU'] = None
-        ret_dict['jungfrau1M_alcove'] = roi_dict
+        ret_dict['jungfrau1M_alcove'] = [ roi_dict ]
     return ret_dict
 
 def isDropped(def_data):
@@ -138,11 +139,10 @@ def define_dets(run):
             # Analysis functions
             # ROIs:
             if detname in ROIs:
-                for iROI,ROI in enumerate(ROIs[detname]['ROIs']):
-                    det.addFunc(ROIFunc(name='ROI_%d'%iROI,
-                                        ROI=ROI,
-                                        writeArea=ROIs[detname]['writeArea'],
-                                        thresADU=ROIs[detname]['thresADU']))
+                if not isinstance(ROIs[detname], list):
+                    ROIs[detname] = [ ROIs[detname] ]
+                for ROI in ROIs[detname]:
+                    det.addFunc(ROIFunc(**ROI))
             # Azimuthal binning
             if detname in az:
                 det.addFunc(azimuthalBinning(**az[detname]))

--- a/smalldata_tools/ana_funcs/azimuthalBinning.py
+++ b/smalldata_tools/ana_funcs/azimuthalBinning.py
@@ -96,7 +96,10 @@ class azimuthalBinning(DetObjectFunc):
         if det.x is not None:
             self.x = det.x.flatten() / 1e3
             self.y = det.y.flatten() / 1e3
-            self.z = det.z.flatten() / 1e3
+            if det.z is not None:
+                self.z = det.z.flatten() / 1e3
+            else:
+                self.z = np.zeros_like(det.x.flatten())
             self.z_off = np.nanmean(self.z) - self.z
             # z_off defined such that z_off >0 is downstream
 

--- a/smalldata_tools/lcls1/DetObject.py
+++ b/smalldata_tools/lcls1/DetObject.py
@@ -366,9 +366,12 @@ class DetObjectClass(object):
         for key in self._storeSum.keys():
             asImg = False
             thres = -1.0e9
+            skipFirst = False
             for skey in key.split("_"):
                 if skey.find("img") >= 0:
                     asImg = True
+                elif skey.find("skip") >= 0:
+                    skipFirst = True
                 else:
                     if skey.find("thresADU") >= 0:
                         thres = float(skey.replace("thresADU", ""))
@@ -400,10 +403,18 @@ class DetObjectClass(object):
                         dat_to_be_summed = np.zeros_like(dat_to_be_summed)
 
             if self._storeSum[key] is None:
-                self._storeSum[key] = dat_to_be_summed.copy()
+                if skipFirst:
+                    self._storeSum[key] = np.zeros_like(dat_to_be_summed)
+                else:
+                    self._storeSum[key] = dat_to_be_summed.copy()
             else:
                 try:
-                    self._storeSum[key] += dat_to_be_summed
+                    if key.find("max") < 0:
+                        self._storeSum[key] += dat_to_be_summed
+                    else:
+                        #look up how to do this.
+                        self._storeSum[key] = np.maximum(self._storeSum[key], dat_to_be_summed)
+
                 except:
                     print("could not add ", dat_to_be_summed)
                     print("could not to ", self._storeSum[key])

--- a/smalldata_tools/lcls1/DetObject.py
+++ b/smalldata_tools/lcls1/DetObject.py
@@ -412,8 +412,10 @@ class DetObjectClass(object):
                     if key.find("max") < 0:
                         self._storeSum[key] += dat_to_be_summed
                     else:
-                        #look up how to do this.
-                        self._storeSum[key] = np.maximum(self._storeSum[key], dat_to_be_summed)
+                        # look up how to do this.
+                        self._storeSum[key] = np.maximum(
+                            self._storeSum[key], dat_to_be_summed
+                        )
 
                 except:
                     print("could not add ", dat_to_be_summed)

--- a/smalldata_tools/lcls1/hutch_default.py
+++ b/smalldata_tools/lcls1/hutch_default.py
@@ -247,10 +247,15 @@ def mfxDetectors(beamCodes=[[-137], [204]], env=None):
                 "atten_trans3",
                 "fee_Attenuator_transmission",
                 "lens_energy",
+                "lens_z",
                 "BeamMonitor_target",
                 "Dg1Ipm_target",
                 "lxt",
+                "lxt_fs_tgt",
+                "lxt_fast",
+                "lxt_fast_mot",
                 "txt",
+                "txt_mot",
             ]
         )
     )


### PR DESCRIPTION
getROIs more standard: return list of ROI-parameters if you want multipleROIs
add some PVs to default MFX EPICS PVlist
azimuthal averaging to work also if det.z is None while det.x/y exist (is the case for the Rayonix)
add skipFirst and max to sum the detector image (skipFirst for Rayonix, max pixel to get powder pattern)
add --use-min-nodes to submission script for lcls1