### PR TITLE
Bug/rebin tt raw cxi

### DIFF
--- a/smalldata_tools/ana_funcs/roi_rebin.py
+++ b/smalldata_tools/ana_funcs/roi_rebin.py
@@ -221,7 +221,7 @@ class rebinFunc(DetObjectFunc):
     def process(self, data):
         # masked array????
         newArray = rebin(data, self.shape)
-        ret_dict = {"data": newArray}
+        ret_dict = {"data": newArray.data}
         return ret_dict
 
 

--- a/smalldata_tools/lcls1/default_detectors.py
+++ b/smalldata_tools/lcls1/default_detectors.py
@@ -631,15 +631,15 @@ class ttRawDetector(DefaultDetector):
         self.subtract_sideband = False
         self.ttCalib = [0.0, 1.0]
         ttCfg = None
-        evrName=None
-        ievr=99
+        evrName = None
+        ievr = 99
         for key in env.configStore().keys():
-            if key.src().__repr__().find('Evr')>0:
-                if int(key.src().__repr__()[-2]) <  ievr:
+            if key.src().__repr__().find("Evr") > 0:
+                if int(key.src().__repr__()[-2]) < ievr:
                     ievr = int(key.src().__repr__()[-2])
-                    evrName = (key.src().__repr__().split('(')[1])[:-1]
+                    evrName = (key.src().__repr__().split("(")[1])[:-1]
         if evrName is None:
-            print('did not find EVR, cannot define ttraw detector ')
+            print("did not find EVR, cannot define ttraw detector ")
             return None
         self.evrdet = psana.Detector(evrName)
         if env is None:

--- a/smalldata_tools/lcls1/default_detectors.py
+++ b/smalldata_tools/lcls1/default_detectors.py
@@ -612,7 +612,7 @@ class l3tDetector(object):
 class ttRawDetector(DefaultDetector):
     def __init__(self, name="ttRaw", env=None):
         self.name = name
-        self.detname = ""
+        self.detname = "have_no_tt"
         self.kind = "stepDown"
         self.weights = None
         self.ttROI_signal = None
@@ -631,7 +631,17 @@ class ttRawDetector(DefaultDetector):
         self.subtract_sideband = False
         self.ttCalib = [0.0, 1.0]
         ttCfg = None
-        self.evrdet = psana.Detector("NoDetector.0:Evr.0")
+        evrName=None
+        ievr=99
+        for key in env.configStore().keys():
+            if key.src().__repr__().find('Evr')>0:
+                if int(key.src().__repr__()[-2]) <  ievr:
+                    ievr = int(key.src().__repr__()[-2])
+                    evrName = (key.src().__repr__().split('(')[1])[:-1]
+        if evrName is None:
+            print('did not find EVR, cannot define ttraw detector ')
+            return None
+        self.evrdet = psana.Detector(evrName)
         if env is None:
             env = psana.Env
             # getting the env this way unfortunatly does not work. Find out how psana.DetNames() does it.
@@ -686,11 +696,6 @@ class ttRawDetector(DefaultDetector):
 
         else:
             super().__init__(self.detname, "ttRaw")
-
-    def in_run(self):
-        if self.detname == "":
-            return False
-        return super().in_run(self)
 
     def setPars(self, ttPars):
         parsList = [


### PR DESCRIPTION
Fixing rebinning to work for the CXI DG2 waveforms - this leaves out the mask, but something went wrong with this.

For the ttraw detector I've removed the hardcoding of using evr0. I have used a different detnames in case on tt-detector is found so that in_run will return false without the overriding&fallback that seems to cause recursion w/ the additional layer we have.

Tested in CXI data.