### PR TITLE
ENH Use maximum for MPI reduction when requesting max projection for detector image sum

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -725,7 +725,10 @@ end_evt_loop = time.time()
 sumDict={'Sums': {}}
 for det in dets:
     for key in det.storeSum().keys():
-        sumData=small_data.sum(det.storeSum()[key])
+        if "max" in key:
+            sumData = small_data.max(det.storeSum()[key])
+        else:
+            sumData = small_data.sum(det.storeSum()[key])
         sumDict['Sums']['%s_%s'%(det._name, key)]=sumData
 if len(sumDict['Sums'].keys())>0:
 #     print(sumDict)


### PR DESCRIPTION
This PR uses the `small_data.max` method to produce a true max projection when reducing across MPI ranks for the detector image sum. This is applied to sum algorithms `calib_max` and variants.

Checklist
-------------
- [x] Use max projection

Testing
-------------