### PR TITLE
ENH Support MFX with LCLS2 DAQ

### DIFF
--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+# These lists are needed, do not delete them
+# If no detector in a given category, leave the corresponding
+# list empty.
+# detectors = ['jungfrau','epix100']
+detectors = []
+integrating_detectors = []
+
+
+# NOTE TO MFX: Do not modify get_intg. This does not apply to MFX but is required for
+# smalldata
+# Comment: the first integrating detector will set the sub-sampling of all
+# integrating detectors.
+def get_intg(run):
+    """
+    Returns
+    -------
+    intg_main (str):  This detector ill be passed to the psana datasource. It should be the SLOWEST of
+                all integrating detectors in the data
+    intg_addl (list of str): The detectors in this list will be analyzed as integrating detectors. It is
+                             important that the readout frequency of these detectors is commensurate and
+                             in-phase with intg_main.
+    """
+    run = int(run)
+    intg_main = None
+    intg_addl = []
+    if run > 0:
+        intg_main = ""
+        intg_addl = []
+    return intg_main, intg_addl
+
+
+def getROIs(run):
+    ret_dict = {}
+
+    jungfrau_roi = {"thresADU": None, "writeArea": True, "calcPars": False, "ROI": None}
+    epix100_roi = {"thresADU": None, "writeArea": True, "calcPars": False, "ROI": None}
+
+    if run > 0:
+        # ret_dict['jungfrau'] = [jungfrau_roi]
+        # ret_dict['epix100'] = [epix100_roi]
+        ...
+    return ret_dict
+
+
+def get_droplet2photon(run):
+    ret_dict = {}
+
+    if run > 0:
+        # ##### epixquad (1010667 setup) #####
+        d2p_dict = {}
+        # droplet args
+        d2p_dict["droplet"] = {
+            #'threshold': 12.5,
+            "threshold": 50,
+            "thresholdLow": 12.5,
+            #'threshold': 70,
+            #'thresholdLow': 25,
+            "thresADU": 70,  # discard droplet whose total ADU is below this value
+            "useRms": False,
+        }
+
+        # droplet2Photons args
+        d2p_dict["d2p"] = {
+            "aduspphot": 20,
+            # 'roi_mask': np.load('path_to_mask.npy'),
+            "cputime": True,
+        }
+        d2p_dict["nData"] = None
+        d2p_dict["get_photon_img"] = False
+
+        ret_dict["epix100"] = d2p_dict
+
+    return ret_dict
+
+
+##########################################################
+# run independent parameters
+##########################################################
+# These lists are either PV names, aliases, or tuples with both.
+# epicsPV = ['las_fs14_controller_time']
+# epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
+#               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
+epicsPV = []
+epicsOncePV = []
+
+
+##########################################################
+# psplot config
+##########################################################
+
+import psplot

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -30,7 +30,9 @@ log_level = "INFO"
 # log_level = DEBUG
 log_format = "[ %(asctime)s | %(levelname)-3s | %(filename)s] %(message)s"
 logging.basicConfig(format=log_format)
-logger.setLevel(logging.INFO)  # Set level here instead of in the basic config so other loggers are  not affected
+logger.setLevel(
+    logging.INFO
+)  # Set level here instead of in the basic config so other loggers are  not affected
 
 if rank == 0:
     logger.info(f"MPI size: {size}")
@@ -94,9 +96,11 @@ def define_dets(run, det_list):
                 for sdetname in rois_args[detname]:
                     funcname = "%s__%s" % (sdetname, "ROI")
                     if rank == 0:
-                        print(f"sdetname {sdetname} args: {rois_args[detname][sdetname]}, func name: {funcname}")
+                        print(
+                            f"sdetname {sdetname} args: {rois_args[detname][sdetname]}, func name: {funcname}"
+                        )
                     RF = hsdROIFunc(
-                        name= funcname,
+                        name=funcname,
                         writeArea=True,
                         ROI=rois_args[detname][sdetname],
                     )
@@ -123,21 +127,21 @@ def define_dets(run, det_list):
                 print(f"\n\nSETTING UP DROPLET TO PHOTON FOR {det._name}")
                 print(json.dumps(d2p_args[detname], indent=4))
                 print("\n")
-            if 'nData' in d2p_args[detname]:  # defines how sparsifcation is saved
-                nData = d2p_args[detname].pop('nData')
+            if "nData" in d2p_args[detname]:  # defines how sparsifcation is saved
+                nData = d2p_args[detname].pop("nData")
             else:
                 nData = None
-            if 'get_photon_img' in d2p_args[detname]:  # save unsparsified image or not
-                unsparsify = d2p_args[detname].pop('get_photon_img')
+            if "get_photon_img" in d2p_args[detname]:  # save unsparsified image or not
+                unsparsify = d2p_args[detname].pop("get_photon_img")
             else:
                 unsparsify = False
 
             # Make individual analysis functions
             # (i) droplet
-            droplet_dict = d2p_args[detname]['droplet']
+            droplet_dict = d2p_args[detname]["droplet"]
             dropfunc = dropletFunc(**droplet_dict)
             # (ii) droplet2Photon
-            d2p_dict = d2p_args[detname]['d2p']
+            d2p_dict = d2p_args[detname]["d2p"]
             drop2phot_func = droplet2Photons(**d2p_dict)
             # (iii) sparsify
             sparsify = sparsifyFunc(nData=nData)
@@ -165,11 +169,15 @@ def define_dets(run, det_list):
             det.addFunc(SimpleHitFinder(**wfs_hitfinder_args[detname]))
 
         if detname in wfs_svd_args:
-            if isinstance(wfs_svd_args[detname], list):  # handle mutliple channel on the same det
+            if isinstance(
+                wfs_svd_args[detname], list
+            ):  # handle mutliple channel on the same det
                 for i_ch, ch in enumerate(wfs_svd_args[detname]):
                     # Check that the basis file exists, skip instantiation if not
                     if not os.path.isfile(ch["basis_file"]):
-                        logger.info(f"SVD basis file for {detname} ch{i_ch} cannot be found. Will not instantiate SvdFit for it.")
+                        logger.info(
+                            f"SVD basis file for {detname} ch{i_ch} cannot be found. Will not instantiate SvdFit for it."
+                        )
                         continue
                     this_func = SvdFit(**ch)
                     det.addFunc(this_func)
@@ -194,7 +202,11 @@ if rank == 0:
 
 from smalldata_tools.utilities import printMsg, checkDet
 from smalldata_tools.common.detector_base import detData, getUserData, getUserEnvData
-from smalldata_tools.lcls2.default_detectors import detOnceData, epicsDetector, genericDetector
+from smalldata_tools.lcls2.default_detectors import (
+    detOnceData,
+    epicsDetector,
+    genericDetector,
+)
 from smalldata_tools.lcls2.hutch_default import defaultDetectors
 from smalldata_tools.lcls2.DetObject import DetObject
 
@@ -211,7 +223,7 @@ from smalldata_tools.ana_funcs.waveformFunc import (
     hsdsplitFunc,
     hsdBaselineCorrectFunc,
     hitFinderCFDFunc,
-    hsdROIFunc
+    hsdROIFunc,
 )
 from smalldata_tools.ana_funcs.droplet import dropletFunc
 from smalldata_tools.ana_funcs.photons import photonFunc
@@ -225,7 +237,7 @@ from psmon import publish
 
 
 # Constants
-HUTCHES = ["TMO", "RIX", "UED"]
+HUTCHES = ["TMO", "RIX", "UED", "MFX"]
 
 S3DF_BASE = Path("/sdf/data/lcls/ds/")
 FFB_BASE = Path("/cds/data/drpsrcf/")
@@ -455,15 +467,23 @@ if intg_main is not None and intg_main != "":
         if intg_main not in detnames:
             skip_intg = True  # skip integrating detector setup
             if rank == 0:
-                logger.error(f"Main integrating detector {intg_main} not found in the data.")
+                logger.error(
+                    f"Main integrating detector {intg_main} not found in the data."
+                )
                 logger.error("Skipping integrating detectors.")
-                logger.error("Please check the integrating detector list in the config.")
+                logger.error(
+                    "Please check the integrating detector list in the config."
+                )
         else:
             datasource_args["intg_det"] = intg_main
             datasource_args["intg_delta_t"] = args.intg_delta_t
             datasource_args["batch_size"] = 1
-            os.environ["PS_SMD_N_EVENTS"] = "1"  # must be 1 for any non-zero value of delta_t
-            integrating_detectors = [intg_main] + intg_addl  # for the detector instantiation
+            os.environ["PS_SMD_N_EVENTS"] = (
+                "1"  # must be 1 for any non-zero value of delta_t
+            )
+            integrating_detectors = [
+                intg_main
+            ] + intg_addl  # for the detector instantiation
     ds = None
     thisrun = None
 
@@ -487,7 +507,9 @@ thisrun = next(ds.runs())
 
 # Generate smalldata object
 if ds.unique_user_rank():
-    logger.info("Opening the h5file %s, gathering at %d" % (h5_f_name, args.gather_interval))
+    logger.info(
+        "Opening the h5file %s, gathering at %d" % (h5_f_name, args.gather_interval)
+    )
 if args.psplot_live_mode:
     if ds.unique_user_rank():
         logger.info("Setting up psplot_live plots.")
@@ -562,7 +584,9 @@ if not ds.is_srv():  # srv nodes do not have access to detectors.
         logger.info(f"Detectors: {[det._name for det in dets]}")
         logger.info(f"Integrating detectors: {[det._name for det in int_dets]}")
     logger.debug(f"Rank {rank} detectors: {[det._name for det in dets]}")
-    logger.debug(f"Rank {rank} integrating detectors: {[det._name for det in int_dets]}")
+    logger.debug(
+        f"Rank {rank} integrating detectors: {[det._name for det in int_dets]}"
+    )
 
     det_presence = {}
     if args.full:
@@ -629,7 +653,7 @@ for evt_num, evt in enumerate(event_iter):
             det.processSums()
             # print(userDict[det._name])
         except Exception as e:
-            logger.warning(f'Failed analyzing det {det} on evt {evt_num}')
+            logger.warning(f"Failed analyzing det {det} on evt {evt_num}")
             print(e)
             pass
 
@@ -701,11 +725,9 @@ for evt_num, evt in enumerate(event_iter):
                             )  # may not work for arrays....
                     else:
                         userDictInt[det._name][k] = v
-                        normdict[det._name][k] = (
-                            v * 0
-                        )  # may not work for arrays....
+                        normdict[det._name][k] = v * 0  # may not work for arrays....
                 # print(userDictInt)
-                small_data.event(evt, userDictInt, align_group='intg')
+                small_data.event(evt, userDictInt, align_group="intg")
             except:
                 print(f"Bad int_det processing on evt {evt_num}")
                 pass
@@ -750,10 +772,10 @@ for evt_num, evt in enumerate(event_iter):
                     ],
                 )
             except:
-                print('ARP update post failed')
+                print("ARP update post failed")
                 pass
         elif ds.unique_user_rank():
-                print("Processed evt %d" % evt_num)
+            print("Processed evt %d" % evt_num)
 
 if not ds.is_srv():
     sumDict = {"Sums": {}}

--- a/setup_scripts/smd_setup.sh
+++ b/setup_scripts/smd_setup.sh
@@ -100,8 +100,8 @@ mkdir -p $SDF_BASE/hdf5/smalldata/cube
 mkdir -p $SDF_BASE/stats/summary/Cube
 
 # make arp jobs
-LCLS1_HUTCHES=("xpp" "xcs" "mfx" "cxi" "mec")
-LCLS2_HUTCHES=("tmo" "txi" "rix" "ued")
+LCLS1_HUTCHES=("xpp" "xcs" "cxi" "mec")
+LCLS2_HUTCHES=("tmo" "txi" "rix" "ued" "mfx")
 
 if [ $QUEUE != "0" ]; then
     if [[ ${LCLS1_HUTCHES[@]} =~ $HUTCH ]]; then

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -402,6 +402,7 @@ class Epix10kObject(TiledCameraObject):
         ):
             self.evt.dat *= self.local_gain  # apply own gain
 
+
 class JungfrauObject(TiledCameraObject):
     def __init__(self, det, run, **kwargs):
         super().__init__(det, run, **kwargs)
@@ -460,9 +461,9 @@ class JungfrauObject(TiledCameraObject):
             self.evt.dat *= self.local_gain  # apply own gain
 
         # correct for area of pixels.
-        #if self.areas is not None:
+        # if self.areas is not None:
         #    self.evt.dat /= self.areas
-        #self._getRawShape()
+        # self._getRawShape()
 
 
 class PVObject(CameraObject):

--- a/smalldata_tools/lcls2/default_detectors.py
+++ b/smalldata_tools/lcls2/default_detectors.py
@@ -97,10 +97,11 @@ class genericDetector(DefaultDetector):
     veto fields.
     """
 
-    def __init__(self, detname, run=None, name=None):
+    def __init__(self, detname, run=None, name=None, var_fields=None):
         if name is None:
             name = detname
         super().__init__(detname, name, run)
+        self._var_fields = var_fields
         if self.in_run():
             self._data_field, self._sub_fields = self.get_fields("raw")
 
@@ -108,12 +109,16 @@ class genericDetector(DefaultDetector):
         dl = {}
         if self._data_field is not None:
             for field in self._sub_fields:
+                if self._var_fields is not None and field in self._var_fields:
+                    field_name = f"var_{field}"
+                else:
+                    field_name = field
                 dat = getattr(self._data_field, field)(evt)
                 if dat is None:
                     continue
-                dl[field] = dat
-                if isinstance(dl[field], list):
-                    dl[field] = np.array(dl[field])
+                dl[field_name] = dat
+                if isinstance(dl[field_name], list):
+                    dl[field_name] = np.array(dl[field_name])
         return dl
 
 

--- a/smalldata_tools/lcls2/hutch_default.py
+++ b/smalldata_tools/lcls2/hutch_default.py
@@ -94,8 +94,12 @@ def mfxDetectors(run, beamCodes=[[-137], [-203]]):
     dets.append(genericDetector("ebeamh", run))
     dets.append(genericDetector("pcav", run))
     dets.append(genericDetector("gasdet", run))
-    dets.append(genericDetector("feespec", run))
+    # hproj can also be variable for feespec but in practice isn't...
+    dets.append(
+        genericDetector("feespec", run, var_fields=["FWHM", "peakPos", "peakHeight"])
+    )
     dets.append(ttDetector("alvium_tt", run, saveTraces=False, iocTimetool=True))
+    # dets.append(lightStatus(beam_destination, laser_codes, run))
     dets.append(lightStatusLcls1Timing(beam_las_codes=beamCodes, run=run))
     dets.append(epicsDetector(PVlist=["lxt", "txt"], run=run))
     return dets

--- a/smalldata_tools/lcls2/hutch_default.py
+++ b/smalldata_tools/lcls2/hutch_default.py
@@ -85,7 +85,7 @@ def uedDetectors(run, beamCodes=[[162], [91]]):
     return dets
 
 
-def mfxDetectors(run, beamCodes=[[-137], [-40]]):
+def mfxDetectors(run, beamCodes=[[-137], [-203]]):
     dets = []
     dets.append(scanDetector("scan", run))
     dets.append(genericDetector("timing", run))

--- a/smalldata_tools/lcls2/hutch_default.py
+++ b/smalldata_tools/lcls2/hutch_default.py
@@ -30,6 +30,8 @@ def defaultDetectors(hutch, run=None, env=None):
         dets = rixDetectors(run)
     elif hutch.lower() == "ued":
         dets = uedDetectors(run)
+    elif hutch.lower() == "mfx":
+        dets = mfxDetectors(run)
     else:
         dets = []
     detsInRun = [det for det in dets if det.in_run()]
@@ -80,4 +82,20 @@ def uedDetectors(run, beamCodes=[[162], [91]]):
     dets.append(genericDetector("timing", run))
     # dets.append(lightStatus(beamCodes, run))
     dets.append(epicsDetector(PVlist=["MOTR_AS01_MC06_CH6"], run=run))
+    return dets
+
+
+def mfxDetectors(run, beamCodes=[[-137], [-40]]):
+    dets = []
+    dets.append(scanDetector("scan", run))
+    dets.append(genericDetector("timing", run))
+    dets.append(genericDetector("MfxD1BmMon", run))
+    dets.append(genericDetector("MfxDg2BmMon", run))
+    dets.append(genericDetector("ebeamh", run))
+    dets.append(genericDetector("pcav", run))
+    dets.append(genericDetector("gasdet", run))
+    dets.append(genericDetector("feespec", run))
+    dets.append(ttDetector("alvium_tt", run, saveTraces=False, iocTimetool=True))
+    dets.append(lightStatusLcls1Timing(beam_las_codes=beamCodes, run=run))
+    dets.append(epicsDetector(PVlist=["lxt", "txt"], run=run))
     return dets


### PR DESCRIPTION
This PR provides MFX configuration for smalldata_tools with LCLS2 data. It makes some modifications to `ttDetector` and provides a lightStatus more attuned to hutches still running on LCLS1 timing.

Support for the Jungfrau, FEE (XRT) spectrometer variable length data and ePix100 is also added. Note that `cmpars` and common mode seem to have an indexing bug at the psana level for the ePix100, so for now the options that were previously used in LCLS1 have been commented out.

Checklist
-------------
- [x] `prod_config_mfx.py`
- [x] `ttDetector` supports an `iocTimetool` bool keyword argument to unpack data for IOC-based timetool plugin.
- [x] `lightStatusLcls1Timing` for providing light status in hutches fed by LCLS1 timing (e.g. don't use beam destination)
- [x] Update `smd_setup.sh` and `lcls2_producers/smd_producer.py` to include MFX in the appropriate LCLS2 configuration lists.
- [x] Add `mfxDetectors` to `smalldata_tools/lcls2/hutch_defaults.py`
- [x] `JungfrauObject` to support the JF16M
- [x] Handle variable length fields for `feespec` BLD
- [x] `Epix100Object` to support ePix100

Testing
-------------
Modify `detectors` in `prod_config_mfx.py` for testing.


- `ePix100` -> **Common mode does not seem to work at psana-level, so not currently passing** `cmpars`
```bash
> ./arp_scripts/submit_smd2.sh -d /sdf/scratch/users/d/dorlhiac -n 120 -e mfxdaq23 -r 5 --interactive
# ...
> h5ls /sdf/scratch/users/d/dorlhiac/mfxdaq23_Run0005.h5
Sums                     Group
UserDataCfg              Group
epics_archiver           Group
epix100                  Group
lightStatus              Group
timestamp                Dataset {120}
timing                   Group
> h5ls /sdf/scratch/users/d/dorlhiac/mfxdaq23_Run0005.h5/Sums
epix100_calib            Dataset {704, 768}
> h5ls /sdf/scratch/users/d/dorlhiac/mfxdaq23_Run0005.h5/epix100
droplet_droplet2phot_cputime Dataset {120, 4}
droplet_droplet2phot_prob Dataset {120, 12}
droplet_nDroplets        Dataset {120}
droplet_nDroplets_all    Dataset {120}
```

- `Jungfrau` and `feespec`
```bash
> ./arp_scripts/submit_smd2.sh -d /sdf/scratch/users/d/dorlhiac -n 120 -e mfx101332224 -r 175 --interactive
# ...
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0175.h5
MfxDg2BmMon              Group
Sums                     Group
UserDataCfg              Group
ebeamh                   Group
epics_archiver           Group
feespec                  Group
gasdet                   Group
lightStatus              Group
pcav                     Group
timestamp                Dataset {120}
timing                   Group
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0175.h5/feespec
baseline                 Dataset {120}
com                      Dataset {120}
comRaw                   Dataset {120}
hproj                    Dataset {120, 2048}
hproj_y1                 Dataset {120}
hproj_y2                 Dataset {120}
integral                 Dataset {120}
nPeaks                   Dataset {120}
width                    Dataset {120}
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0175.h5/Sums
jungfrau_calib           Dataset {4, 512, 1024}
```

- `lightStatus` and `ttDetector`
```bash
> ./arp_scripts/submit_smd2.sh -d /sdf/scratch/users/d/dorlhiac -n 120 -e mfx101332224 -r 168 --interactive
# ...
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0168.h5
UserDataCfg              Group
epics_archiver           Group
lightStatus              Group
timestamp                Dataset {120}
timing                   Group
tt                       Group
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0168.h5/tt
ampl                     Dataset {120}
amplnxt                  Dataset {120}
fltpos                   Dataset {120}
fltpos_ps                Dataset {120}
fltposfwhm               Dataset {120}
refampl                  Dataset {120}
> h5ls -d /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0168.h5/lightStatus/xray
xray                     Dataset {120}
    Data:
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
> h5ls -d /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0168.h5/lightStatus/laser
laser                    Dataset {120}
    Data:
         1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0,
         1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1,
         1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1
```