### PR TITLE
ENH New damage and USB Encoder dets and updated MFX config.

### DIFF
--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -4,7 +4,8 @@ import numpy as np
 # If no detector in a given category, leave the corresponding
 # list empty.
 # detectors = ['jungfrau','epix100']
-detectors = []
+detectors = ['epix100', 'alvium', 'jungfrau'] # , 'qadc1']
+#detectors = []
 integrating_detectors = []
 
 
@@ -35,11 +36,19 @@ def getROIs(run):
     ret_dict = {}
 
     jungfrau_roi = {"thresADU": None, "writeArea": True, "calcPars": False, "ROI": None}
-    epix100_roi = {"thresADU": None, "writeArea": True, "calcPars": False, "ROI": None}
+    alv_roi = {"writeArea": True, "calcPars": False, "ROI": None, "thresADU": None}
+
+    epix100_roi = {
+        "thresADU": None,
+        "writeArea": True,
+        "calcPars": False,
+        "ROI": [[0,710],[119,197]]
+    }
 
     if run > 0:
         # ret_dict['jungfrau'] = [jungfrau_roi]
-        # ret_dict['epix100'] = [epix100_roi]
+        ret_dict['epix100'] = [epix100_roi]
+        ret_dict['alvium'] = [alv_roi]
         ...
     return ret_dict
 
@@ -70,10 +79,35 @@ def get_droplet2photon(run):
         d2p_dict["nData"] = None
         d2p_dict["get_photon_img"] = False
 
-        ret_dict["epix100"] = d2p_dict
+        #ret_dict["epix100"] = d2p_dict
 
     return ret_dict
 
+def get_droplet(run):
+    ret_dict = {}
+    if run > 0:
+        dfunc_dict = {}
+        dfunc_dict["threshold"] = 110.0 / 32
+        # dfunc_dict['thresholdLow'] = 10./8
+        dfunc_dict["thresADU"] = 20.0  # 4.
+        dfunc_dict["useRms"] = False
+        ret_dict["epix100"] = dfunc_dict
+    return ret_dict
+
+def get_azav(run):
+    ret_dict = {}
+    if run > 0:
+        az_dict = {"eBeam": 9.8}  # Photon energy in keV
+        az_dict["center"] = [-1107, 918]  # Position in um
+        az_dict["dis_to_sam"] = 92.51  # try to overwrite dis_to_sam
+        az_dict["tx"] = 0  # Tilt in x in degrees
+        az_dict["ty"] = 0  # Tilt in y in degrees
+        az_dict["phiBins"] = 11  # Number of phi bins for azint
+        az_dict["qbin"] = 0.025  # Bin width in q for az int
+        az_dict["userMask"] = None
+        #ret_dict["jungfrau"] = az_dict
+
+    return ret_dict
 
 ##########################################################
 # run independent parameters

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -39,6 +39,10 @@ def DetObject(srcName, run, **kwargs):
         "archon": ArchonObject,
         "jungfrau": JungfrauObject,
     }
+    if "alvium" in srcName:
+        cls = PVObject
+    else:
+        cls = detector_classes[det._dettype]
     cls = detector_classes[det._dettype]
     return cls(det, run, **kwargs)
 

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -38,11 +38,9 @@ def DetObject(srcName, run, **kwargs):
         "piranha4": PiranhaObject,
         "archon": ArchonObject,
         "jungfrau": JungfrauObject,
+        "pv": PVObject, # For alvium etc.
     }
-    if "alvium" in srcName:
-        cls = PVObject
-    else:
-        cls = detector_classes[det._dettype]
+
     cls = detector_classes[det._dettype]
     return cls(det, run, **kwargs)
 

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -38,7 +38,7 @@ def DetObject(srcName, run, **kwargs):
         "piranha4": PiranhaObject,
         "archon": ArchonObject,
         "jungfrau": JungfrauObject,
-        "pv": PVObject, # For alvium etc.
+        "pv": PVObject,  # For alvium etc.
     }
 
     cls = detector_classes[det._dettype]

--- a/smalldata_tools/lcls2/default_detectors.py
+++ b/smalldata_tools/lcls2/default_detectors.py
@@ -252,7 +252,7 @@ class usbEncoder(DefaultDetector):
             if data is not None:
                 for i in range(4):
                     if (desc := channel_descriptions[i]) != "":
-                        dl[desc] = data[desc]
+                        dl[desc] = data[i]
         return dl
 
 

--- a/smalldata_tools/lcls2/default_detectors.py
+++ b/smalldata_tools/lcls2/default_detectors.py
@@ -256,7 +256,6 @@ class usbEncoder(DefaultDetector):
         return dl
 
 
-
 class interpolatedEncoder(DefaultDetector):
     """
     Detector for interpolated encoder.

--- a/smalldata_tools/lcls2/default_detectors.py
+++ b/smalldata_tools/lcls2/default_detectors.py
@@ -91,6 +91,41 @@ def detOnceData(det, data, ts, noarch):
     return data
 
 
+class damageDetector(DefaultDetector):
+    def __init__(self, detname="damage", run=None):
+        self.name = detname
+        self.detname = detname
+        self.detNames = []
+        self.damageDets = []
+        if run is None:
+            return
+        # run.detnames: set[str]
+        for dn in run.detnames:
+            if dn in ("epicsinfo", "triginfo") or "pvdetinfo" in dn:
+                continue
+            self.detNames.append(dn)
+            det = run.Detector(dn)
+            self.damageDets.append(psana.detector.damage.Damage(det.raw))
+        self.detAlias = [det for det in self.detNames]
+
+    def in_run(self):
+        return True
+
+    def data(self, evt):
+        dl = {}
+        for idx, detName in enumerate(self.detNames):
+            damage = self.damageDets[idx].count(evt)
+            val = 0
+            if damage is None:
+                val = 0
+            elif damage == {}:
+                val = 1
+            else:
+                val = 0
+            dl[detName] = val
+        return dl
+
+
 class genericDetector(DefaultDetector):
     """
     Detector to get whatever is under the 'raw' field, minus the default
@@ -191,6 +226,35 @@ class fimfexDetector(DefaultDetector):
                 if isinstance(dl[field], list):
                     dl[field] = np.array(dl[field])
         return dl
+
+
+class usbEncoder(DefaultDetector):
+    """
+    Detector for US Digital USB encoder bld.
+    """
+
+    def __init__(self, detname, run=None, name="enc"):
+        super().__init__(detname, name, run)
+        if self.in_run():
+            self._data_field, self._sub_fields = self.get_fields("raw")
+
+    def data(self, evt):
+        dl = {}
+        if self._data_field is not None and self._sub_fields is not None:
+            channel_descriptions = []
+            data = []
+            for field in self._sub_fields:
+                if field == "descriptions":
+                    channel_descriptions = getattr(self._data_field, field)(evt)
+                else:
+                    data = getattr(self._data_field, field)(evt)
+
+            if data is not None:
+                for i in range(4):
+                    if (desc := channel_descriptions[i]) != "":
+                        dl[desc] = data[desc]
+        return dl
+
 
 
 class interpolatedEncoder(DefaultDetector):

--- a/smalldata_tools/lcls2/hutch_default.py
+++ b/smalldata_tools/lcls2/hutch_default.py
@@ -89,11 +89,13 @@ def mfxDetectors(run, beamCodes=[[-137], [-203]]):
     dets = []
     dets.append(scanDetector("scan", run))
     dets.append(genericDetector("timing", run))
-    dets.append(genericDetector("MfxD1BmMon", run))
+    dets.append(genericDetector("MfxDg1BmMon", run))
     dets.append(genericDetector("MfxDg2BmMon", run))
     dets.append(genericDetector("ebeamh", run))
     dets.append(genericDetector("pcav", run))
     dets.append(genericDetector("gasdet", run))
+    dets.append(genericDetector("qadc_ch0", run))
+    dets.append(genericDetector("qadc_ch1", run))
     # hproj can also be variable for feespec but in practice isn't...
     dets.append(
         genericDetector("feespec", run, var_fields=["FWHM", "peakPos", "peakHeight"])
@@ -102,4 +104,6 @@ def mfxDetectors(run, beamCodes=[[-137], [-203]]):
     # dets.append(lightStatus(beam_destination, laser_codes, run))
     dets.append(lightStatusLcls1Timing(beam_las_codes=beamCodes, run=run))
     dets.append(epicsDetector(PVlist=["lxt", "txt"], run=run))
+    dets.append(damageDetector(run=run))
+    dets.append(usbEncoder(detname="MfxUsbEncoder01", run=run))
     return dets


### PR DESCRIPTION
This PR provides addtional detectors for MFX running with the LCLS2 DAQ. It adds the `usbEncoder` for the fast delay stages and a `damageDetector` which behaves like the LCLS1 version (will not work for RIX). Updates the producer file and config file to include droplet.

Checklist
-------------
- [x] `damageDetector` for damage statistics. **This probably only works for MFX/hutches on NC timing/hutches without integrating detectors**
- [x] `usbEncoder` detector for US digital encoder bld.
- [x] Update `prod_config_mfx.py` for droplet/azav.
- [x] Update `smd_producer.py` for droplet/azav.

Testing
-------------
Run 211 of `mfx101332224`:

```bash
> /sdf/data/lcls/ds/mfx/mfx101332224/results/smalldata_tools/arp_scripts/submit_smd2.sh --partition milano --postRuntable --nodes 2 --wait --interactive --nevents 5 --experiment mfx101332224 --run 211 --directory /sdf/scratch/users/d/dorlhiac
# ...
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] ebeamh: ebeamh
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] pcav: pcav
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] gasdet: gasdet
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] feespec: feespec
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] lightStatus: timing
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] damage: damage
[ 2025-05-09 10:06:29,070 | INFO | smd_producer.py] enc: MfxUsbEncoder01
```

See damage detector:

```bash
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0211_part0.h5/damage
MfxDg1BmMon              Dataset {5/Inf}
MfxDg2BmMon              Dataset {5/Inf}
MfxUsbEncoder01          Dataset {5/Inf}
ebeamh                   Dataset {5/Inf}
feespec                  Dataset {5/Inf}
gasdet                   Dataset {5/Inf}
jungfrau                 Dataset {5/Inf}
pcav                     Dataset {5/Inf}
timing                   Dataset {5/Inf}
> h5ls -d /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0211_part0.h5/damage/feespec
feespec                  Dataset {5/Inf}
    Data:
        (0) 0, 0, 0, 0, 0
> h5ls -d /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0211_part0.h5/damage/MfxDg2BmMon
MfxDg2BmMon              Dataset {5/Inf}
    Data:
        (0) 1, 1, 1, 1, 1
```

See usb encoder:

```bash
> h5ls /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0211_part0.h5/enc
lasDelay                 Dataset {5/Inf}
> h5ls -d /sdf/scratch/users/d/dorlhiac/mfx101332224_Run0211_part0.h5/enc
lasDelay                 Dataset {5/Inf}
    Data:
        (0) -1.2658921395489, -1.2658921395489, -1.2658921395489, -1.2658921395489, -1.2658921395489
```