### PR TITLE
Add Xcs hutch defaults dccm

### DIFF
--- a/lcls2_producers/prod_config_qrix.py
+++ b/lcls2_producers/prod_config_qrix.py
@@ -20,7 +20,7 @@ def get_intg(run):
     intg_main = None
     intg_addl = []
     if run > 0:
-        intg_main = 'archon'
+        intg_main = "archon"
         intg_addl = []
 
     return intg_main, intg_addl
@@ -36,23 +36,22 @@ def getROIs(run):
 
     if run > 0:
         # Save the full DET.
-        ret_dict['q_piranha'] = [full_roi]
-        ret_dict['q_atmopal'] = [full_roi]
-        ret_dict['archon'] = [full_roi]
-
+        ret_dict["q_piranha"] = [full_roi]
+        ret_dict["q_atmopal"] = [full_roi]
+        ret_dict["archon"] = [full_roi]
 
         # and the FIM waveforms
         ret_dict["rix_fim0"] = [full_roi]
         ret_dict["rix_fim1"] = [full_roi]
-        ret_dict['qrix_w8'] = [full_roi]
+        ret_dict["qrix_w8"] = [full_roi]
 
         # hsd channels used by qRIXS
         hsd_dict = {}
-        hsd_dict['hsd_0'] = [0,-1]
+        hsd_dict["hsd_0"] = [0, -1]
         # hsd_dict["hsd_1"] = [3000, 8000]
         # hsd_dict["hsd_2"] = [3000, 8000]
-        hsd_dict['hsd_3'] = [0,-1]
-        ret_dict['hsd'] = hsd_dict
+        hsd_dict["hsd_3"] = [0, -1]
+        ret_dict["hsd"] = hsd_dict
 
     return ret_dict
 

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -488,7 +488,7 @@ if args.nevents != 0:
     datasource_args["max_events"] = args.nevents
 
 # Setup if integrating detectors are requested.
-if hasattr(config, 'get_intg'):
+if hasattr(config, "get_intg"):
     intg_main, intg_addl = config.get_intg(run)
     integrating_detectors = []
     skip_intg = False

--- a/smalldata_tools/lcls1/hutch_default.py
+++ b/smalldata_tools/lcls1/hutch_default.py
@@ -206,6 +206,12 @@ def xcsDetectors(beamCodes=[[-137], [89]], env=None):
                 "lxt",
                 "lxt_ttc",
                 "lxe",
+                "dccm_th1",
+                "dccm_th2",
+                "dccm_th1_setpoint",
+                "dccm_th2_setpoint",
+                "dccm_E",
+                "dccm_E_setpoint"
             ]
         )
     )

--- a/smalldata_tools/lcls1/hutch_default.py
+++ b/smalldata_tools/lcls1/hutch_default.py
@@ -211,7 +211,7 @@ def xcsDetectors(beamCodes=[[-137], [89]], env=None):
                 "dccm_th1_setpoint",
                 "dccm_th2_setpoint",
                 "dccm_E",
-                "dccm_E_setpoint"
+                "dccm_E_setpoint",
             ]
         )
     )


### PR DESCRIPTION
Add DCCM motors to the XCS hutch default pv list.