### PR TITLE
adding save_tiff arg to xcs cube, or else fails

### DIFF
--- a/lcls1_producers/cube_config_xcs.py
+++ b/lcls1_producers/cube_config_xcs.py
@@ -52,3 +52,6 @@ hist_list = {
     #'tt/AMPL': [],
     #'tt/FLTPOSFWHM': []
 }
+
+# save as tiff file (ingore unless MEC)
+save_tiff = False


### PR DESCRIPTION
Fails looking for the "save_tiff" argument without this line, other hutches have it.