### PR TITLE
ENH LCLS2 Sum Algorithm Config

### DIFF
--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -104,8 +104,7 @@ def get_sum_algos(run):
 
     Possible algorithms:
     - calib: Sum calib.
-    - calib_dropped: Sum calib of dropped.
-    - calib_dropped_square: Square of image.
+    - calib_square: Square of image.
     - calib_thresADU1 (or 5, 10 etc): Apply threshold using the number after `ADU`
     - calib_max: Maximum projection instead of sum.
     """
@@ -113,8 +112,7 @@ def get_sum_algos(run):
     if run > 0:
         ret_dict["all"] = [
             "calib",
-            "calib_dropped",
-            "calib_dropped_square",
+            "calib_square",
             "calib_thresADU1",
         ]
         ret_dict["jungfrau"] = ["calib_thresADU5", "calib_max"]

--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -95,6 +95,27 @@ def get_azav(run):
 
     return ret_dict
 
+def get_sum_algos(run):
+    """Specify detector sum algorithms for specific detectors or `all` detectors.
+
+    Provide a list of algorithms for each detector `detname`, or provide a list
+    under the `all` key which will be applied to each detector.
+
+    Possible algorithms:
+    - calib: Sum calib.
+    - calib_dropped: Sum calib of dropped.
+    - calib_dropped_square: Square of image.
+    - calib_thresADU1 (or 5, 10 etc): Apply threshold using the number after `ADU`
+    - calib_max: Maximum projection instead of sum.
+    """
+    ret_dict = {}
+    if run > 0:
+        ret_dict["all"] = ["calib", "calib_dropped", "calib_dropped_square", "calib_thresADU1"]
+        ret_dict["jungfrau"] = ["calib_thresADU5", "calib_max"]
+        # ret_dict["epix100_0"] = []
+        # ret_dict["epix100_1"] = []
+    return ret_dict
+
 
 ##########################################################
 # run independent parameters

--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -95,6 +95,7 @@ def get_azav(run):
 
     return ret_dict
 
+
 def get_sum_algos(run):
     """Specify detector sum algorithms for specific detectors or `all` detectors.
 
@@ -110,7 +111,12 @@ def get_sum_algos(run):
     """
     ret_dict = {}
     if run > 0:
-        ret_dict["all"] = ["calib", "calib_dropped", "calib_dropped_square", "calib_thresADU1"]
+        ret_dict["all"] = [
+            "calib",
+            "calib_dropped",
+            "calib_dropped_square",
+            "calib_thresADU1",
+        ]
         ret_dict["jungfrau"] = ["calib_thresADU5", "calib_max"]
         # ret_dict["epix100_0"] = []
         # ret_dict["epix100_1"] = []

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -56,6 +56,7 @@ def define_dets(run, det_list):
     droplet_args = {}
     azav_args = {}
     polynomial_args = {}
+    sum_algo_args = {}
 
     # Get the functions arguments from the production config
     if "getROIs" in dir(config):
@@ -76,6 +77,8 @@ def define_dets(run, det_list):
         azav_args = config.get_azav(run)
     if "get_polynomial_correction" in dir(config):
         polynomial_args = config.get_polynomial_correction(run)
+    if "get_sum_algos" in dir(config):
+        sum_algo_args = config.get_sum_algos(run)
 
     dets = []
 
@@ -228,7 +231,18 @@ def define_dets(run, det_list):
                 poly_corr_func.addFunc(proj_func)
             obj.addFunc(poly_corr_func)
 
-        det.storeSum(sumAlgo="calib")
+        if sum_algo_args == {}:
+            # Store calib by default even if algos. dictionary not defined
+            det.storeSum(sumAlgo="calib")
+        else:
+            # Add `all` algorithms
+            if "all" in sum_algo_args:
+                for algo in sum_algo_args["all"]:
+                    det.storeSum(sumAlgo=algo)
+            if detname in sum_algo_args:
+                for algo in sum_algo_args[detname]:
+                    det.storeSum(sumAlgo=algo)
+
         logger.debug(f"Rank {rank} Add det {detname}: {det}")
         dets.append(det)
 

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -207,7 +207,13 @@ class DetObjectClass(object):
                     self._storeSum[key] = dat_to_be_summed.copy()
             else:
                 try:
-                    self._storeSum[key] += dat_to_be_summed
+                    if key.find("max") < 0:
+                        self._storeSum[key] += dat_to_be_summed
+                    else:
+                        # Care about nan behaviour?
+                        self._storeSum[key] = np.maximum(
+                            self._storeSum[key], dat_to_be_summed
+                        )
                 except:
                     print("could not add ", dat_to_be_summed)
                     print("could not to ", self._storeSum[key])


### PR DESCRIPTION
This PR adds configuration options for sum algorithms in the LCLS2 producer.

Note this exists similarly in LCLS1 (minus the `"all"` key), but the retrieval function is named differently. The camel-case LCLS1 version is different than the naming style used for the LCLS2 producer, but for consistency we can use it here if that is preferred.

Checklist
-------------
- [x] Update `smd_producer.py` (LCLS2 version) for sum algorithm selection.
  - Includes an `"all"` key which allows application of the algoirthm to all detectors
  - Sets a default sum algorithm if none are defined.
- [x] Update hutch configuration.
- [x] Add maximum projection to sum algorithms in the LCLS2 `DetObject`.

Testing
-------------
Tested against `mfx100864724` using the standard `prod_config_mfx.py`, except with the only change being the addition of the `jungfrau` to the detectors list:
```bash
>  ./arp_scripts/submit_smd2.sh -e mfx100864724 -r 206 --directory /sdf/scratch/users/d/dorlhiac --nevents 5 --interactive
Sourcing LCLS-II environment
SIT_ENV_DIR: /sdf/group/lcls/ds/ana
SIT_PSDM_DATA: /sdf/data/lcls/ds/
PS_EB_NODES: 1
PS_SRV_NODES: 1
Producer command: /sdf/scratch/users/d/dorlhiac/work/smalldata_tools/lcls2_producers/smd_producer.py --experiment mfx100864724 --run 206 --directory /sdf/scratch/users/d/dorlhiac --nevents 5
# ...
[ 2025-06-30 08:52:40,431 | INFO | smd_producer.py] Detectors: ['epix100_0', 'epix100_1', 'jungfrau']
[ 2025-06-30 08:52:40,431 | INFO | smd_producer.py] Integrating detectors: []
[ 2025-06-30 08:52:40,431 | INFO | smd_producer.py] And now the event loop user....
# ...
```

Produced expected output:
```bash
> h5ls mfx100864724_Run0206.h5/Sums
epix100_0_calib          Dataset {704, 768}
epix100_0_calib_square   Dataset {704, 768}
epix100_0_calib_thresADU1 Dataset {704, 768}
epix100_1_calib          Dataset {704, 768}
epix100_1_calib_square   Dataset {704, 768}
epix100_1_calib_thresADU1 Dataset {704, 768}
jungfrau_calib           Dataset {32, 512, 1024}
jungfrau_calib_max       Dataset {32, 512, 1024}
jungfrau_calib_square    Dataset {32, 512, 1024}
jungfrau_calib_thresADU1 Dataset {32, 512, 1024}
jungfrau_calib_thresADU5 Dataset {32, 512, 1024}
```

Also ran a test removing the sum algorithm configuration by setting `run < 0` in the conditional in the function, and the default path still records the `calib` sum.
```bash
> h5ls mfx100864724_Run0206.h5/Sums
epix100_0_calib          Dataset {704, 768}
epix100_1_calib          Dataset {704, 768}
jungfrau_calib           Dataset {32, 512, 1024}
```

Deleting the `get_sum_algos` function all together produces the same behaviour as above.
```bash
> h5ls mfx100864724_Run0206.h5/Sums
epix100_0_calib          Dataset {704, 768}
epix100_1_calib          Dataset {704, 768}
jungfrau_calib           Dataset {32, 512, 1024}
```