### PR TITLE
Piranha overflow bug

### DIFF
--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -717,7 +717,13 @@ class PiranhaObject(WaveformObject):
 
     def getData(self, evt):
         super(PiranhaObject, self).getData(evt)
-        self.evt.dat = self.det.raw.raw(evt)
+        try:
+            self.evt.dat = self.det.raw.raw(evt).astype(int)
+        except:
+            print(
+                "piranha: Could not cast piranha to array, set to None"
+            )
+            self.evt.dat = None
         return
 
 

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -720,9 +720,7 @@ class PiranhaObject(WaveformObject):
         try:
             self.evt.dat = self.det.raw.raw(evt).astype(int)
         except:
-            print(
-                "piranha: Could not cast piranha to array, set to None"
-            )
+            print("piranha: Could not cast piranha to array, set to None")
             self.evt.dat = None
         return
 


### PR DESCRIPTION
A fix to avoid type overflow problems with the piranha camera and integrating detectors. 
The data is converted from the default uint16 to int.