### PR TITLE
BUG Unbound error if no ROI defined.

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -47,7 +47,7 @@ def define_dets(run):
     # Assumes that the config file with function parameters definition
     # has been imported under "config"
 
-    rois_args = {}  
+    roi_args = {}
     mectt_args = {}
     azint_args = {}
     azintpyfai_args = {}


### PR DESCRIPTION
This PR fixes a minor bug when no ROIs are defined in LCLS1.

The `roi_args` variable which gets used for the ROIs is unbound if not in the config file. The empty dict had a different name `rois_args`. This makes the names identical.

Checklist
-------------
- [x] Fix name of `roi_args` to prevent unbound variable error in LCLS1.

Testing
-------------
