### PR TITLE
BUG Fix conditional in job definition script

### DIFF
--- a/setup_scripts/make_arp_jobs_lcls2.py
+++ b/setup_scripts/make_arp_jobs_lcls2.py
@@ -84,7 +84,7 @@ smd_job_def = {
 
 job_defs.append(smd_job_def)
 
-if "all_events" in args:
+if args.all_events:
     smd_job_def["parameters"] += " --all_events"
     smd_job_def["trigger"] = "MANUAL"
     job_defs.append(smd_job_def)


### PR DESCRIPTION
This PR fixes a minor bug in the ARP job setup script. The conditional checking `--all_events` previously always evaluated to `True`. This leads to jobs being created with with the `--all_events` flag, and their trigger being `MANUAL`, regardless of if you passed `--all_events` to the setup script.

Checklist
-------------
- [x] Fix conditional.

Testing
-------------
