### PR TITLE
MNT epicsArchFilePV and allow tuples for epicsPV

### DIFF
--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -124,11 +124,17 @@ def get_sum_algos(run):
 ##########################################################
 # run independent parameters
 ##########################################################
-# These lists are either PV names, aliases, or tuples with both.
-# epicsPV = ['las_fs14_controller_time']
+# Will be taken from the archiver
+# This list is PV names or tuples (PV name, alias)
+epicsPV = []
+
+# Will be taken from the XTC (epicsArch file)
+# NOTE: Data appears to be shot-to-shot in the HDF5 but is NOT! This for convenience only
+# These lists are either PV names, aliases, or tuples (PV name, alias)
+# epicsArchFilePV = ['las_fs14_controller_time']
 # epicsOncePV = ['m0c0_vset', ('TMO:PRO2:MPOD:01:M2:C3:VoltageMeasure', 'MyAlias'),
 #               'IM4K4:PPM:SPM:VOLT_RBV', "FOO:BAR:BAZ", ("X:Y:Z", "MCBTest"), "A:B:C"]
-epicsPV = []
+epicsArchFilePV = []
 epicsOncePV = []
 
 

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -640,7 +640,9 @@ if not ds.is_srv():  # srv nodes do not have access to detectors.
                 epicsDetector(PVlist=epicsPV, name="epicsAll", run=thisrun)
             )
     elif hasattr(config, "epicsArchFilePV") and len(config.epicsArchFilePV) > 0:
-        default_dets.append(epicsDetector(PVlist=config.epicsArchFilePV, name='epicsUser', run=thisrun))
+        default_dets.append(
+            epicsDetector(PVlist=config.epicsArchFilePV, name="epicsUser", run=thisrun)
+        )
 
     if len(config.epicsOncePV) > 0:
         EODet = epicsDetector(PVlist=config.epicsOncePV, name="epicsOnce", run=thisrun)


### PR DESCRIPTION
This PR is a minor change to LCLS2 production to allow the old shot-by-shot convience PV storage. It is added in as a new field `epicsArchFilePV`. The handling of `epicsPV` PVs is updated to allow the user to specify options in the old format of `("PV:NAME", "alias")` without errors from the archiver Python package.

Checklist
-------------
- [x] Add `epicsArchFilePV` list with the old behaviour of LCLS1 `epicsPV`.
- [x] Update the LCLS2 `epicsPV` handling, which goes via archiver, to allow tuples in the list of format `("PV:NAME", "alias")`

Testing
-------------