### PR TITLE
ENH Make use of `ws-jwt` endpoints for API calls

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -174,7 +174,7 @@ fpathup = '/'.join(fpath.split('/')[:-1])
 sys.path.append(fpathup)
 logger.info(f'\n{fpathup}')
 
-from smalldata_tools.utilities import printMsg, checkDet
+from smalldata_tools.utilities import printMsg, checkDet, postRunTable
 from smalldata_tools.common.detector_base import getUserData, getUserEnvData
 from smalldata_tools.lcls1.default_detectors import detData, detOnceData
 from smalldata_tools.lcls1.default_detectors import ttRawDetector
@@ -688,7 +688,7 @@ dets_time_start = (start_setup_dets-start_job)/60
 dets_time_end = (end_setup_dets-start_job)/60
 evt_time_start = (start_evt_loop-start_job)/60
 evt_time_end = (end_evt_loop-start_job)/60
-logger.debug(f"##### Timing benchmarks core {ds.rank}: ##### """)
+logger.debug(f"##### Timing benchmarks core {ds.rank}: ##### ")
 logger.debug(f'Setup dets: \n\tStart: {dets_time_start:.2f} min\n\tEnd: {dets_time_end:.2f} min')
 logger.debug(f'\tDuration:{dets_time_end-dets_time_start:.2f}')
 logger.debug(f'Event loop: \n\tStart: {evt_time_start:.2f} min\n\tEnd: {evt_time_end:.2f} min')
@@ -725,18 +725,7 @@ if args.postRuntable and ds.rank==0:
     else:
         runtable_data["SmallData%s"%locStr]="done"
     time.sleep(5)
-    ws_url = args.url + "/run_control/{0}/ws/add_run_params".format(args.experiment)
-    print('URL:',ws_url)
-    #krbheaders = KerberosTicket("HTTP@" + urlparse(ws_url).hostname).getAuthHeaders()
-    #r = requests.post(ws_url, headers=krbheaders, params={"run_num": args.run}, json=runtable_data)
-    user=(args.experiment[:3]+'opr').replace('dia','mcc')
 
-    with open('/sdf/group/lcls/ds/tools/forElogPost.txt') as reader:
-        answer = reader.readline()
-    r = requests.post(ws_url, params={"run_num": args.run}, json=runtable_data, 
-                      auth=HTTPBasicAuth(args.experiment[:3]+'opr', answer[:-1]))
-    print(r)
+    postRunTable(runtable_data=runtable_data, experiment=args.experiment, run=args.run)
     if det_presence!={}:
-        rp = requests.post(ws_url, params={"run_num": args.run}, json=det_presence,
-                           auth=HTTPBasicAuth(args.experiment[:3]+'opr', answer[:-1]))
-        print(rp)
+        postRunTable(runtable_data=det_presence, experiment=args.experiment, run=args.run)

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -1020,4 +1020,6 @@ if args.postRuntable and ds.unique_user_rank():
 
     postRunTable(runtable_data=runtable_data, experiment=args.experiment, run=args.run)
     if det_presence != {}:
-        postRunTable(runtable_data=det_presence, experiment=args.experiment, run=args.run)
+        postRunTable(
+            runtable_data=det_presence, experiment=args.experiment, run=args.run
+        )

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -258,7 +258,7 @@ sys.path.append(fpathup)
 if rank == 0:
     logger.info(fpathup)
 
-from smalldata_tools.utilities import printMsg, checkDet
+from smalldata_tools.utilities import postRunTable
 from smalldata_tools.common.detector_base import detData, getUserData, getUserEnvData
 from smalldata_tools.lcls2.default_detectors import (
     detOnceData,
@@ -1018,25 +1018,6 @@ if args.postRuntable and ds.unique_user_rank():
 
     time.sleep(5)
 
-    ws_url = args.url + "/run_control/{0}/ws/add_run_params".format(args.experiment)
-    logger.debug("URL: ", ws_url)
-    user = (args.experiment[:3] + "opr").replace("dia", "mcc")
-    if os.environ.get("ARP_LOCATION", None) == "S3DF":
-        with open("/sdf/group/lcls/ds/tools/forElogPost.txt") as reader:
-            answer = reader.readline()
-
-        r = requests.post(
-            ws_url,
-            params={"run_num": args.run},
-            json=runtable_data,
-            auth=HTTPBasicAuth(args.experiment[:3] + "opr", answer[:-1]),
-        )
-        logger.debug(r)
+    postRunTable(runtable_data=runtable_data, experiment=args.experiment, run=args.run)
     if det_presence != {}:
-        rp = requests.post(
-            ws_url,
-            params={"run_num": args.run},
-            json=det_presence,
-            auth=HTTPBasicAuth(args.experiment[:3] + "opr", answer[:-1]),
-        )
-        logger.debug(rp)
+        postRunTable(runtable_data=det_presence, experiment=args.experiment, run=args.run)

--- a/smalldata_tools/utilities.py
+++ b/smalldata_tools/utilities.py
@@ -1152,6 +1152,7 @@ def KdeCuts(values, bandwidth="scott", percentile=[0.1, 99.9], nBins=1000):
     retDict["rightMaxDistToLine"] = [dxRight, dyRight]
     return retDict
 
+
 def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> Optional[str]:
     """Get the current active experiment for a hutch.
 
@@ -1184,9 +1185,7 @@ def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> Optional[str]:
         return None
 
 
-def postRunTable(
-    runtable_data: dict, experiment: str, run: str
-):
+def postRunTable(runtable_data: dict, experiment: str, run: str):
     base_url_auth = "https://pswww.slac.stanford.edu/ws-auth/lgbk/"
     base_url_jwt: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
     endpoint: str = f"run_control/{experiment}/ws/add_run_params"
@@ -1216,10 +1215,11 @@ def postRunTable(
                 # No kerberos ticket. Out of luck
                 logger.warning("Cannot post run table.")
                 return None
-            auth_jwt = { "Authorization": auth_token }
+            auth_jwt = {"Authorization": auth_token}
             resp = _postRunTable(runtable_data, run, full_url_jwt, auth_jwt)
     logger.debug(resp)
     return None
+
 
 def _postRunTable(
     runtable_data: dict, run: str, url: str, auth: Union[dict, HTTPBasicAuth]
@@ -1267,7 +1267,7 @@ def getElogBasicAuth(exp: str) -> HTTPBasicAuth:
     -------
     http_auth (HTTPBasicAuth) Authentication for eLog API.
     """
-    opr_name: str = f"{exp[:3]}opr".replace("dia","mcc")
+    opr_name: str = f"{exp[:3]}opr".replace("dia", "mcc")
     auth_path: str = "/sdf/group/lcls/ds/tools/forElogPost.txt"
 
     with open(auth_path, "r") as f:
@@ -1413,6 +1413,7 @@ def get_calib_file(run, directory, f_end=".data"):
             f"No matching calibration file found for run {run} in directory {directory}."
         )
     return f"{directory}{background}"
+
 
 def request_arp_token(exp: str, lifetime: int = 300) -> Optional[str]:
     """Request an ARP token via Kerberos endpoint.

--- a/smalldata_tools/utilities.py
+++ b/smalldata_tools/utilities.py
@@ -1152,26 +1152,94 @@ def KdeCuts(values, bandwidth="scott", percentile=[0.1, 99.9], nBins=1000):
     retDict["rightMaxDistToLine"] = [dxRight, dyRight]
     return retDict
 
+def get_elog_active_expmt(hutch: str, *, endstation: int = 0) -> Optional[str]:
+    """Get the current active experiment for a hutch.
+
+    This function is one of two functions to manage the HTTP request independently.
+    This is because it does not require an authorization object, and its result
+    is needed for the generic function `elog_http_request` to work properly.
+
+    Args:
+        hutch (str): The hutch to get the active experiment for.
+
+        endstation (int): The hutch endstation to get the experiment for. This
+            should generally be 0.
+    """
+
+    base_url: str = "https://pswww.slac.stanford.edu/ws/lgbk/lgbk"
+    endpoint: str = "ws/activeexperiment_for_instrument_station"
+    url: str = f"{base_url}/{endpoint}"
+    params: dict[str, str] = {"instrument_name": hutch, "station": f"{endstation}"}
+    resp: requests.models.Response = requests.get(url, params)
+    if resp.status_code > 300:
+        logger.error(
+            f"Error getting current experiment!\n\t\tIncorrect hutch: '{hutch}'?"
+        )
+        return None
+    if resp.json()["success"]:
+        return resp.json()["value"]["name"]
+    else:
+        msg: str = resp.json()["error_msg"]
+        logger.error(f"Error getting current experiment! Err: {msg}")
+        return None
+
 
 def postRunTable(
-    runtable_data, experiment, run, url="https://pswww.slac.stanford.edu/ws-auth/lgbk/"
+    runtable_data: dict, experiment: str, run: str
 ):
-    ws_url = url + "/run_control/{0}/ws/add_run_params".format(experiment)
-    print("URL:", ws_url)
-    user = experiment[:3] + "opr"
-    elogPostFile = "/sdf/group/lcls/ds/tools/forElogPost.txt"
-    with open(elogPostFile, "r") as reader:
-        answer = reader.readline()
-    r = requests.post(
-        ws_url,
-        params={"run_num": run},
-        json=runtable_data,
-        auth=HTTPBasicAuth(experiment[:3] + "opr", answer[:-1]),
-    )
-    # we might need to use this for non=current expetiments. Currently does not work in ARP
-    # krbheaders = KerberosTicket("HTTP@" + urlparse(ws_url).hostname).getAuthHeaders()
-    # r = requests.post(ws_url, headers=krbheaders, params={"run_num": args.run}, json=runtable_data)
-    print(r)
+    base_url_auth = "https://pswww.slac.stanford.edu/ws-auth/lgbk/"
+    base_url_jwt: str = "https://pswww.slac.stanford.edu/ws-jwt/lgbk/lgbk"
+    endpoint: str = f"run_control/{experiment}/ws/add_run_params"
+
+    full_url_auth: str = f"{base_url_auth}/{endpoint}"
+    full_url_jwt: str = f"{base_url_jwt}/{endpoint}"
+
+    auth_token: Optional[str] = os.getenv("Authorization")
+    resp: requests.models.Response
+    if auth_token:
+        # Use token-based first
+        # This works for active and inactive experiments
+        auth_jwt: dict[str, str] = {
+            "Authorization": auth_token,
+        }
+        resp = _postRunTable(runtable_data, run, full_url_jwt, auth_jwt)
+    else:
+        # No token - so ran from command line
+        if experiment == get_elog_active_expmt(hutch=experiment[:3]):
+            # We have an active experiment, so can use operator authentication
+            auth_opr: HTTPBasicAuth = getElogBasicAuth(exp=experiment)
+            resp = _postRunTable(runtable_data, run, full_url_auth, auth_opr)
+        else:
+            # Not analyzing an active experiment. We'll attempt kerberos
+            auth_token = request_arp_token(exp=experiment, lifetime=10)
+            if auth_token is None:
+                # No kerberos ticket. Out of luck
+                logger.warning("Cannot post run table.")
+                return None
+            auth_jwt = { "Authorization": auth_token }
+            resp = _postRunTable(runtable_data, run, full_url_jwt, auth_jwt)
+    logger.debug(resp)
+    return None
+
+def _postRunTable(
+    runtable_data: dict, run: str, url: str, auth: Union[dict, HTTPBasicAuth]
+) -> requests.models.Response:
+    resp: requests.models.Response
+    if isinstance(auth, dict):
+        resp = requests.post(
+            url,
+            params={"run_num": run},
+            json=runtable_data,
+            headers=auth,
+        )
+    else:
+        resp = requests.post(
+            url,
+            params={"run_num": run},
+            json=runtable_data,
+            auth=auth,
+        )
+    return resp
 
 
 ## function that chops the 64 bit time integer into soemthing a bit more realistic
@@ -1199,8 +1267,7 @@ def getElogBasicAuth(exp: str) -> HTTPBasicAuth:
     -------
     http_auth (HTTPBasicAuth) Authentication for eLog API.
     """
-    opr_name: str = f"{exp[:3]}opr"
-    hostname: str = socket.gethostname()
+    opr_name: str = f"{exp[:3]}opr".replace("dia","mcc")
     auth_path: str = "/sdf/group/lcls/ds/tools/forElogPost.txt"
 
     with open(auth_path, "r") as f:
@@ -1346,3 +1413,45 @@ def get_calib_file(run, directory, f_end=".data"):
             f"No matching calibration file found for run {run} in directory {directory}."
         )
     return f"{directory}{background}"
+
+def request_arp_token(exp: str, lifetime: int = 300) -> Optional[str]:
+    """Request an ARP token via Kerberos endpoint.
+
+    A token is required for job submission.
+
+    Parameters
+    ----------
+    exp : str
+        The experiment to request the token for. All tokens are scoped to a single
+        experiment.
+
+    lifetime : int
+        The lifetime, in minutes, of the token. After the token expires, it can no
+        longer be used. The maximum time you can request is 480 minutes (i.e. 8 hours).
+
+    Returns
+    -------
+    token : str
+        The token that can be used for API requests.
+    """
+    from kerberos import GSSError  # type: ignore
+    from krtc import KerberosTicket  # type: ignore
+
+    try:
+        krbheaders: dict[str, str] = KerberosTicket(
+            "HTTP@pswww.slac.stanford.edu"
+        ).getAuthHeaders()
+    except GSSError:
+        logger.warning(
+            "Cannot proceed without credentials. Try running `kinit` from the command-line."
+        )
+        return None
+    base_url: str = "https://pswww.slac.stanford.edu/ws-kerb/lgbk/lgbk"
+    token_endpoint: str = (
+        f"{base_url}/{exp}/ws/generate_arp_token?token_lifetime={lifetime}"
+    )
+    resp: requests.models.Response = requests.get(token_endpoint, headers=krbheaders)
+    resp.raise_for_status()
+    token: str = resp.json()["value"]
+    formatted_token: str = f"Bearer {token}"
+    return formatted_token


### PR DESCRIPTION
This PR makes use of `ws-jwt` endpoints for API calls.

The advantage is that authentication works against these endpoints for active and inactive experiments.

The procedure is now:
- Check to see if you have a token (e.g. submitted via ARP) -> Use `ws-jwt` endpoint
- If no token (e.g. from command-line), check to see if active experiment -> Use `ws-auth` endpoint as before
- If no token and not an active experiment, try and request a token (kerberos) -> Use the `ws-jwt` endpoint
- If unable to request a token. Well you're out of luck again...

Checklist
-------------
- [x] Add common functions for posting to `smalldata_tools/utilities.py` 
- [x] Update `lcls1_producers/smd_producer.py` to use the common function
- [x] Update `lcls2_producers/smd_producer.py` to use the common function

Testing
-------------
