### PR TITLE
ENH: add more customization to the job submission

### DIFF
--- a/arp_scripts/run_smd2.sh
+++ b/arp_scripts/run_smd2.sh
@@ -2,6 +2,7 @@
 
 #SBATCH --job-name=smd
 #SBATCH --exclusive
+#SBATCH --cpu-per-task=1
 # Note: when run trough sbatch, this script runs from the slurm scheduler folder
 
 usage()


### PR DESCRIPTION
Adding new command-line options for more customizable SLURM job submissions, improving help documentation.

**Enhancements to SLURM job submission and script usability:**

* Added new command-line options to `submit_smd2.sh` for specifying `--ntasks`, `--memory`, and other SLURM-related parameters, enabling users to fully customize their job submissions.
* Improved the help message in `submit_smd2.sh` to clearly document all available options and provide example usage.
* Implemented argument validation to ensure that when `--ntasks` is specified, both `--nodes` and `--srv_cores` must also be provided, preventing misconfiguration.
* Updated the logic to assemble the SBATCH_ARGS string.