### PR TITLE
ENH Map pixel indices to physical coordinates pyFAI detector

### DIFF
--- a/smalldata_tools/ana_funcs/azav_pyfai.py
+++ b/smalldata_tools/ana_funcs/azav_pyfai.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 try:
@@ -6,8 +5,6 @@ try:
 except ModuleNotFoundError:
     print("pyFAI not available on LCLS-II env")
 
-### Can we put LCLSGeom in environment?
-sys.path.append("/sdf/home/l/lconreux/LCLSGeom")
 from LCLSGeom.manager import get_geometry
 from LCLSGeom.converter import PsanaToPyFAI
 
@@ -62,7 +59,7 @@ class azav_pyfai(DetObjectFunc):
             raise ValueError("Either a poni file or ai_kwargs must be provided to initialize the azimuthal integrator.")
 
         # integration arguments
-        self.pol_factor = kwargs.pop("polarization_factor", -1)        
+        self.pol_factor = kwargs.pop("polarization_factor", -1)  # Vertical Polarization by default post Run 18   
         self.npts = kwargs.pop("npts", 256)
         self.npts_az = kwargs.pop("npts_az", 360)
         # self.radial_range = kwargs.pop('radial_range',None)
@@ -101,7 +98,7 @@ class azav_pyfai(DetObjectFunc):
         # instantiate PyFAI detector first 
         # this adds the detector name mentioned in the poni file to pyFAI detector registry
         # reading the poni file will not throw an error if the detector name is not in the registry
-        detector = PsanaToPyFAI.convert(metrology)
+        detector = PsanaToPyFAI.convert(metrology, det.det.alias)
         # if detector is 3D (panels, slow, fast), then this scripts creates a fake 2D detector by
         # squeezing the panel and slow dimensions.
         # the 3D pixel layout is passed using the metrology data !

--- a/smalldata_tools/ana_funcs/azav_pyfai.py
+++ b/smalldata_tools/ana_funcs/azav_pyfai.py
@@ -6,9 +6,10 @@ try:
 except ModuleNotFoundError:
     print("pyFAI not available on LCLS-II env")
 
-### Can LCLSGeom be passed through LUTE or put in environment?
-sys.path.append("/sdf/group/lcls/ds/tools/LCLSGeom")
-from LCLSGeom.psana2.converter import PsanaToPyFAI
+### Can we put LCLSGeom in environment?
+sys.path.append("/sdf/home/l/lconreux/LCLSGeom")
+from LCLSGeom.manager import get_geometry
+from LCLSGeom.converter import PsanaToPyFAI
 
 from smalldata_tools.common.detector_base import DetObjectFunc
 
@@ -55,48 +56,13 @@ class azav_pyfai(DetObjectFunc):
         self.mask = kwargs.pop("userMask", None)
         self.threshold = kwargs.pop("thres", None)
         self.return2d = kwargs.pop("return2d", "False")
-        # Hardcoded metrology file for now, but I can get it from the jungfrau psana Detector object, just unsure on how to do it !
-        # That allows us to map pixel indices to physical coordinates, without assembling and casting the image in a wrong 2D plane.
-        self.geometry_path = "/sdf/home/l/lconreux/geom/mfx100852324/geometry-def-jungfrau16M.data"
-        converter = PsanaToPyFAI(self.geometry_path)
-        pyFAI_detector = converter.detector
         self.poni_file = kwargs.pop("poni_file", None)
-        if self.poni_file is not None:
-            ai = pyFAI.load(str(self.poni_file))
-            dico = ai.getPyFAI()
-            self.ai = pyFAI.AzimuthalIntegrator(
-                detector=pyFAI_detector,
-                dist=dico.pop("dist"),
-                poni1=dico.pop("poni1"),
-                poni2=dico.pop("poni2"),
-                rot1=dico.pop("rot1"),
-                rot2=dico.pop("rot2"),
-                rot3=dico.pop("rot3"),
-                wavelength=dico.pop("wavelength"),
-            )
-        else:
-            self._ai_kwargs = kwargs.pop("ai_kwargs", None)
-            if self._ai_kwargs is not None:
-                self.ai = pyFAI.AzimuthalIntegrator(
-                    detector=pyFAI_detector,
-                    **self._ai_kwargs
-                )
-        # we should have code that extract setup parameters
-        #    in case people mess w/ the input
-        # we should also extra q/theta/... bins for plotting later.
-        azcfg = self.ai.get_config()
-        dcfg = azcfg.pop("detector_config")
-        ocfg = dcfg.pop("orientation")
-        for k, v in azcfg.items():
-            setattr(self, "azcfg_%s" % k, v)
-        for k, v in dcfg.items():
-            setattr(self, "azcfg_det_%s" % k, v)
-        setattr(self, "azcfg_detorientation", ocfg.value)
-        setattr(self, "azcfg_qvals", self.ai.get_qa())
-        # setattr(self,'azcfg_qvals',self.ai.get_qa())
+        self._ai_kwargs = kwargs.pop("ai_kwargs", None)
+        if self._ai_kwargs is None and self.poni_file is None:
+            raise ValueError("Either a poni file or ai_kwargs must be provided to initialize the azimuthal integrator.")
 
         # integration arguments
-        self.pol_factor = kwargs.pop("polarization_factor", 1)
+        self.pol_factor = kwargs.pop("polarization_factor", -1)        
         self.npts = kwargs.pop("npts", 256)
         self.npts_az = kwargs.pop("npts_az", 360)
         # self.radial_range = kwargs.pop('radial_range',None)
@@ -130,6 +96,55 @@ class azav_pyfai(DetObjectFunc):
                         self.mask = None
         if self.mask is not None and self.mask.ndim == 3:
             self.mask = np.reshape(self.mask, (self.mask.shape[0]*self.mask.shape[1], self.mask.shape[2]))
+      
+        metrology = get_geometry(det.det.alias)
+        # instantiate PyFAI detector first 
+        # this adds the detector name mentioned in the poni file to pyFAI detector registry
+        # reading the poni file will not throw an error if the detector name is not in the registry
+        detector = PsanaToPyFAI.convert(metrology)
+        # if detector is 3D (panels, slow, fast), then this scripts creates a fake 2D detector by
+        # squeezing the panel and slow dimensions.
+        # the 3D pixel layout is passed using the metrology data !
+        if self._ai_kwargs is None:
+            ai = pyFAI.load(self.poni_file)
+            self._ai_kwargs = ai.getPyFAI()
+
+        if self._units == "q_A^-1":
+            if "wavelength" not in self._ai_kwargs:
+                raise ValueError("Wavelength must be provided when using q_A^-1 units. Check poni file or ai_kwargs inputs.")
+            self.ai = pyFAI.AzimuthalIntegrator(
+                detector=detector,
+                dist=self._ai_kwargs["dist"],
+                poni1=self._ai_kwargs["poni1"],
+                poni2=self._ai_kwargs["poni2"],
+                rot1=self._ai_kwargs["rot1"],
+                rot2=self._ai_kwargs["rot2"],
+                rot3=self._ai_kwargs["rot3"],
+                wavelength=self._ai_kwargs["wavelength"],
+            )
+        else:
+            self.ai = pyFAI.AzimuthalIntegrator(
+                detector=detector,
+                dist=self._ai_kwargs["dist"],
+                poni1=self._ai_kwargs["poni1"],
+                poni2=self._ai_kwargs["poni2"],
+                rot1=self._ai_kwargs["rot1"],
+                rot2=self._ai_kwargs["rot2"],
+                rot3=self._ai_kwargs["rot3"],
+            )
+        # we should have code that extract setup parameters
+        #    in case people mess w/ the input
+        # we should also extra q/theta/... bins for plotting later.
+        azcfg = self.ai.get_config()
+        dcfg = azcfg.pop("detector_config")
+        ocfg = dcfg.pop("orientation")
+        for k, v in azcfg.items():
+            setattr(self, "azcfg_%s" % k, v)
+        for k, v in dcfg.items():
+            setattr(self, "azcfg_det_%s" % k, v)
+        setattr(self, "azcfg_detorientation", ocfg.value)
+        setattr(self, "azcfg_qvals", self.ai.get_qa())
+        # setattr(self,'azcfg_qvals',self.ai.get_qa())
         print(f"Azimuthal integrator:\n{self.ai}")
         return
 
@@ -140,6 +155,8 @@ class azav_pyfai(DetObjectFunc):
         if self.threshold is not None:
             data[data < self.threshold] = 0
         if data.ndim == 3:
+            # instead of assembling the image, now we just squeeze the panel and slow dimensions
+            # so that image and detector have same shape.
             data = np.reshape(data, (data.shape[0]*data.shape[1], data.shape[2]))
         out = self._process(data)
         return out

--- a/smalldata_tools/ana_funcs/azav_pyfai.py
+++ b/smalldata_tools/ana_funcs/azav_pyfai.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 
 try:
@@ -5,9 +6,11 @@ try:
 except ModuleNotFoundError:
     print("pyFAI not available on LCLS-II env")
 
-from smalldata_tools.common.detector_base import DetObjectFunc
-from smalldata_tools.utilities import image_from_dxy
+### Can LCLSGeom be passed through LUTE or put in environment?
+sys.path.append("/sdf/group/lcls/ds/tools/LCLSGeom")
+from LCLSGeom.psana2.converter import PsanaToPyFAI
 
+from smalldata_tools.common.detector_base import DetObjectFunc
 
 class azav_pyfai(DetObjectFunc):
     """
@@ -49,23 +52,35 @@ class azav_pyfai(DetObjectFunc):
     def __init__(self, **kwargs):
         self._name = kwargs.get("name", "pyfai")
         super(azav_pyfai, self).__init__(**kwargs)
-
         self.mask = kwargs.pop("userMask", None)
         self.threshold = kwargs.pop("thres", None)
         self.return2d = kwargs.pop("return2d", "False")
-
-        # azimuthal integrator argument
+        # Hardcoded metrology file for now, but I can get it from the jungfrau psana Detector object, just unsure on how to do it !
+        # That allows us to map pixel indices to physical coordinates, without assembling and casting the image in a wrong 2D plane.
+        self.geometry_path = "/sdf/home/l/lconreux/geom/mfx100852324/geometry-def-jungfrau16M.data"
+        converter = PsanaToPyFAI(self.geometry_path)
+        pyFAI_detector = converter.detector
         self.poni_file = kwargs.pop("poni_file", None)
         if self.poni_file is not None:
-            self.ai = pyFAI.load(str(self.poni_file))
+            ai = pyFAI.load(str(self.poni_file))
+            dico = ai.getPyFAI()
+            self.ai = pyFAI.AzimuthalIntegrator(
+                detector=pyFAI_detector,
+                dist=dico.pop("dist"),
+                poni1=dico.pop("poni1"),
+                poni2=dico.pop("poni2"),
+                rot1=dico.pop("rot1"),
+                rot2=dico.pop("rot2"),
+                rot3=dico.pop("rot3"),
+                wavelength=dico.pop("wavelength"),
+            )
         else:
             self._ai_kwargs = kwargs.pop("ai_kwargs", None)
-            assert (
-                self._ai_kwargs is not None
-            ), "Need either a calibration file or a set of keywords arguments to instantiate the pyFAI integrator."
-            # self.ai = pyFAI.azimuthalIntegrator.AzimuthalIntegrator(**self._ai_kwargs) # why does it not work?
-            self.ai = pyFAI.AzimuthalIntegrator(**self._ai_kwargs)
-        print(f"Created azimuthal integrator for {self._name}")
+            if self._ai_kwargs is not None:
+                self.ai = pyFAI.AzimuthalIntegrator(
+                    detector=pyFAI_detector,
+                    **self._ai_kwargs
+                )
         # we should have code that extract setup parameters
         #    in case people mess w/ the input
         # we should also extra q/theta/... bins for plotting later.
@@ -94,27 +109,6 @@ class azav_pyfai(DetObjectFunc):
 
     def setFromDet(self, det):
         super(azav_pyfai, self).setFromDet(det)
-        # geometry
-        self.ix = det.ix
-        self.iy = det.iy
-
-        if self.poni_file is None:  # use calib value if calib file is given
-            if len(det.pixelsize) == 2:
-                if det.pixelsize[0] > 1:
-                    self.ai.pixel1 = det.pixelsize[0] * 1e-6
-                    self.ai.pixel2 = det.pixelsize[1] * 1e-6
-                else:
-                    self.ai.pixel1 = det.pixelsize[0]
-                    self.ai.pixel2 = det.pixelsize[1]
-            else:
-                if det.pixelsize[0] > 1:
-                    self.ai.pixel1 = det.pixelsize[0] * 1e-6
-                    self.ai.pixel2 = det.pixelsize[0] * 1e-6
-                else:
-                    self.ai.pixel1 = det.pixelsize[0]
-                    self.ai.pixel2 = det.pixelsize[0]
-
-        # use cmask by default. Note: pyFAI uses 0 for valid pixel.
         if (
             self.mask is not None
             and det.cmask is not None
@@ -135,12 +129,7 @@ class azav_pyfai(DetObjectFunc):
                     except:
                         self.mask = None
         if self.mask is not None and self.mask.ndim == 3:
-            maskInv = ~(self.mask.astype(bool))
-            self.mask = image_from_dxy(self.mask, self.ix, self.iy)
-            maskInvImg = image_from_dxy(maskInv, self.ix, self.iy)
-            maskImg = ~(maskInvImg)
-            self.mask = maskImg
-
+            self.mask = np.reshape(self.mask, (self.mask.shape[0]*self.mask.shape[1], self.mask.shape[2]))
         print(f"Azimuthal integrator:\n{self.ai}")
         return
 
@@ -149,9 +138,9 @@ class azav_pyfai(DetObjectFunc):
 
     def process(self, data):
         if self.threshold is not None:
-            data[data < threshold] = 0
+            data[data < self.threshold] = 0
         if data.ndim == 3:
-            data = image_from_dxy(data, self.ix, self.iy)
+            data = np.reshape(data, (data.shape[0]*data.shape[1], data.shape[2]))
         out = self._process(data)
         return out
 
@@ -178,5 +167,4 @@ class azav_pyfai(DetObjectFunc):
                 method="cython",
                 **self._azav_kwargs,
             )
-
             return {"azav": I, "q": q}


### PR DESCRIPTION
# Description

This PR aims at improving the pyFAI azimuthal integration script. Rather than assembling the images at each event, we define a mapping between pixel and physical space only once through the use of LCLSGeom creating a pyFAI detector object with pixel coordinates. This discards the need for casting 3D images into hard-coded 2D assembled images.

## Checklist

- [ ] Add `LCLSGeom` to path/environment (see Address Issues)
- [x] Modifications to `smalldata_tools/ana_funcs/azav_pyfai.py`
  
 ## PR Type
 
 - [x] Enhancement: provide better and faster pyFAI azimuthal integration pipeline
 
 ## Address Issues
 
 - [ ] How to import `LCLSGeom` at top of script
   - [ ] Pass it through `LUTE` ?
   - [ ] Add to environment ? 
   
## Test on LCLS-II detectors

- Test was done through `lute` on `mfx101343025` run 8 at `/sdf/data/lcls/ds/mfx/mfx101343025/results/lconreux/launchpad/pyfai_ENH` for logs.

- Command run:
1. Source `/sdf/data/lcls/ds/mfx/mfx101343025/results/lconreux/lute/install/bin/activate_installation`
2. Run:
`submit_slurm -t SmallDataProducer2 -c /sdf/data/lcls/ds/mfx/mfx101343025/results/lconreux/yamls/smd_pyfai_config_1.yaml -e mfx101343025 -r 8 --psana2 --partition=milano --account=lcls:prjlute22 --nodes=8 --ntasks-per-node=50 --exclusive`

- Output logs `/sdf/data/lcls/ds/mfx/mfx101343025/results/lconreux/launchpad/pyfai_ENH/SmallDataProducer2Test_mfx101343025_r0008_2026-03-11_18-27-45_23131031.out`:
```
INFO:lute.execution.executor:Joining: 8 files --> mfx101343025_Run0008.h5

INFO:lute.execution.executor:([ 2026-03-11 11:37:23,557 | INFO | smd_producer.py] Getting epics data from Archiver (rank: 9)
)
INFO:lute.execution.executor:########## JOB TIME: 9.098399 minutes ###########
Last Event: 270

INFO:lute.execution.executor:
ERROR:lute.io.elog:eLog Update Failed! JID_UPDATE_COUNTERS is not defined!
ERROR:lute.io._db.v2.api:Cannot setup permissions on database!
INFO:lute.execution.executor:Exiting after Task completion.
```