### PR TITLE
BUG/MNT Guard uses of `cd` from bash function overrides

### DIFF
--- a/arp_scripts/cubeRun.sh
+++ b/arp_scripts/cubeRun.sh
@@ -130,7 +130,7 @@ ARP_LOCATION="${ARP_LOCATION:=LOCAL}"
 export EXPERIMENT=$EXP
 export RUN_NUM=$RUN
 
-export MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+export MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ABS_PATH=`echo $MYDIR | sed  s/arp_scripts/lcls1_producers/g`
 
 # Default queue and S3DF flag

--- a/arp_scripts/lets_cube_lcls2.sh
+++ b/arp_scripts/lets_cube_lcls2.sh
@@ -95,7 +95,7 @@ export EXPERIMENT=$EXP
 export RUN_NUM=$RUN
 
 # Export useful path
-CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+CWD="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 export SMD_ROOT=`echo $CWD | sed  "s|/arp_scripts||g"`
 
 export SIT_ENV_DIR="/sdf/group/lcls/ds/ana"

--- a/arp_scripts/make_svd_basis.sh
+++ b/arp_scripts/make_svd_basis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Export useful path
-MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 SMD_ROOT=`echo $MYDIR | sed  "s|/arp_scripts||g"`
 
 PY_EXE="$SMD_ROOT/smalldata_tools/ana_funcs/svd_waveform/make_waveform_basis_psana2.py"

--- a/arp_scripts/submit_plots.sh
+++ b/arp_scripts/submit_plots.sh
@@ -86,7 +86,7 @@ SIT_ENV_DIR="/sdf/group/lcls/ds/ana"
 QUEUE=${QUEUE:='milano'}
 ACCOUNT=${ACCOUNT:="lcls:$EXP"}
 
-export MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+export MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 RUN="${RUN_NUM:=$RUN}" # default to the environment variable if submitted from the elog
 EXP="${EXPERIMENT:=$EXP}" # default to the environment variable if submitted from the elog

--- a/arp_scripts/submit_smd.sh
+++ b/arp_scripts/submit_smd.sh
@@ -150,7 +150,7 @@ ARP_LOCATION="${ARP_LOCATION:=LOCAL}"
 export EXPERIMENT=$EXP
 export RUN_NUM=$RUN
 
-export MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+export MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Default queue and S3DF flag
 DEFQUEUE='psanaq'

--- a/arp_scripts/submit_smd2.sh
+++ b/arp_scripts/submit_smd2.sh
@@ -119,7 +119,7 @@ export EXPERIMENT=$EXP
 export RUN_NUM=$RUN
 
 # Export useful path
-MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 export SMD_ROOT=`echo $MYDIR | sed  "s|/arp_scripts||g"`
 
 export SIT_ENV_DIR="/sdf/group/lcls/ds/ana"

--- a/setup_scripts/smd_setup.sh
+++ b/setup_scripts/smd_setup.sh
@@ -72,7 +72,7 @@ umask 002
 QUEUE=${QUEUE:=0}
 CUBE=${CUBE:=0}
 PSPLOT_LIVE=${PSPLOT_LIVE:=0}
-MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )" # gets the script directory.
+MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )" # gets the script directory.
 
 # check that the script is run on relevant nodes
 if [ $(echo $HOSTNAME | grep -ic -e "sdf") -eq 0 ]


### PR DESCRIPTION

This PR addresses a possible issue which has caused issues for psana and has the potential to cause issues in many repos using a common pattern to determine directories based on a source file location:
- The use of cd for determining a bash files location failed because users are overriding the builtin cd command with a function. Probably for use with AI agents. A fairly simple guard for this is to replace the use of cd with builtin cd ensuring an overrides are avoided when we need to use the command.

See e.g., LUTE changes here: https://github.com/slac-lcls/lute/pull/141

There is a conversation in Slack for discussion of the problem when it caused issue for finding the psana release.

Checklist
-------------
- [x] Update use of cd to builtin cd in bash scripts using it to deremine source file location.
