### PR TITLE
BUG/UTL Switch to use of SHA for pinning actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,19 +9,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0                     # v7
         with:
           ref: "${{ github.event.pull_request.head.ref }}"
           repository: "${{ github.event.pull_request.head.repo.full_name }}"
       
       - name: apply-black
-        uses: psf/black@stable
-        with:
+        uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e                            # v26.5.1
+        with:                                                                               # (equal to stable on 2026/06/30)
           options: "--verbose --color"
           src: "./smalldata_tools ./setup_scripts ./lcls2_producers"
       
       - name: commit-black
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "Auto-commit black formatting"
           commit_user_name: "Autoformatter"

--- a/smalldata_tools/ana_funcs/azimuthalBinning.py
+++ b/smalldata_tools/ana_funcs/azimuthalBinning.py
@@ -239,7 +239,7 @@ class azimuthalBinning(DetObjectFunc):
         # include geometrical corrections
         geom = (self.dis_to_sam + self.z_off) / r
         # pixels are not perpendicular to scattered beam
-        geom *= ((self.dis_to_sam + self.z_off) / r)**2
+        geom *= ((self.dis_to_sam + self.z_off) / r) ** 2
         # scattered radiation is proportional to 1/r^2
         self.msg("calculating normalization...", cr=0)
         self.geom = geom


### PR DESCRIPTION
This PR  updates the GitHub actions to use SHA commit hashes to pin the various stages. This is a requirement of SLAC enterprise policies as opposed to using version specifiers (tags etc.).

The PR also advances the versions of the used components due to the deprecation of node.js 20.

Checklist
-------------
- [x] Switch to commit SHA hashs for action pinning.
