### PR TITLE
ENH Common mode support for LCLS2

### DIFF
--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -654,7 +654,7 @@ for evt_num, evt in enumerate(ds.events()):
 
     #the ARP will pass run & exp via the enviroment, if I see that info, the post updates
     if ( (evt_num<100 and evt_num%10==0) or (evt_num<1000 and evt_num%100==0) or (evt_num%1000==0)):
-        if os.environ.get('ARP_JOB_ID', None) is not None:
+        if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
             if ds.size == 1:
                 requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Current Event</b>", "value": evt_num+1}])
             elif ds.rank == 0:
@@ -703,7 +703,7 @@ if ds.rank==0:
 
 #finishing up here....
 logger.debug('rank {0} on {1} is finished'.format(ds.rank, hostname))
-if os.environ.get('ARP_JOB_ID', None) is not None:
+if os.environ.get('ARP_JOB_ID', None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
     if ds.size > 1:
         if ds.rank == 0:
             requests.post(os.environ["JID_UPDATE_COUNTERS"], json=[{"key": "<b>Last Event</b>", "value": "~ %d cores * %d evts"%(ds.size,evt_num)},{"key": "<b>Duration</b>", "value": "%f min"%(prod_time)}])

--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -7,6 +7,26 @@ detectors = ["epix100_0", "epix100_1", "alvium"]  # , 'qadc1']
 # detectors = []
 integrating_detectors = []
 
+def get_det_params(run):
+    ret_dict = {}
+
+    # cmpars (tuple) - common mode parameters
+    #      [0] - (int) algorithm number - currently this number does not matter,
+    #            median algorithm is used everywhere.
+    #      [1] - (uint) mode bitword - 1/2/4 : correction applied in rows per
+    #            bank / columns per bank / banks.
+    #      [2] - (float) absolute maximal allowed correction. Correction is not
+    #            applied if exceeds this value.
+    #      [3] - (uint) minimal number of (anmasked) pixels to evaluate correction.
+    epix_params = {
+        "cmpars": (7, 7, 100, 10)
+    }
+
+    if run > 0:
+        ret_dict["epix100_0"] = epix_params
+        ret_dict["epix100_1"] = epix_params
+
+    return ret_dict
 
 def getROIs(run):
     ret_dict = {}

--- a/lcls2_producers/prod_config_mfx.py
+++ b/lcls2_producers/prod_config_mfx.py
@@ -7,6 +7,7 @@ detectors = ["epix100_0", "epix100_1", "alvium"]  # , 'qadc1']
 # detectors = []
 integrating_detectors = []
 
+
 def get_det_params(run):
     ret_dict = {}
 
@@ -18,15 +19,14 @@ def get_det_params(run):
     #      [2] - (float) absolute maximal allowed correction. Correction is not
     #            applied if exceeds this value.
     #      [3] - (uint) minimal number of (anmasked) pixels to evaluate correction.
-    epix_params = {
-        "cmpars": (7, 7, 100, 10)
-    }
+    epix_params = {"cmpars": (7, 7, 100, 10)}
 
     if run > 0:
         ret_dict["epix100_0"] = epix_params
         ret_dict["epix100_1"] = epix_params
 
     return ret_dict
+
 
 def getROIs(run):
     ret_dict = {}

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -54,6 +54,7 @@ def define_dets(run, det_list):
     # Assumes that the config file with function parameters definition
     # has been imported under "config"
 
+    user_det_params = {}
     rois_args = []  # special implementation as a list to support multiple ROIs.
     dimgs_args = {}
     wfs_int_args = {}
@@ -68,6 +69,8 @@ def define_dets(run, det_list):
     pressio_compression_args = {}
 
     # Get the functions arguments from the production config
+    if "get_det_params" in dir(config):
+        user_det_params = config.get_det_params(run)
     if "getROIs" in dir(config):
         rois_args = config.getROIs(run)
     if "getDetImages" in dir(config):
@@ -100,6 +103,8 @@ def define_dets(run, det_list):
 
         # Common mode (default: None)
         common_mode = None
+        if detname in user_det_params and "cmpars" in user_det_params[detname]:
+            common_mode = user_det_params[detname]["cmpars"]
 
         if not havedet:
             continue
@@ -1057,7 +1062,7 @@ logger.debug("rank {0} on {1} is finished".format(rank, hostname))
 #        cmd = ['timestamp_sort_h5', h5_f_name, h5_f_name]
 
 if ds.unique_user_rank():
-    if os.environ.get("ARP_JOB_ID", None) is not None:
+    if os.environ.get("ARP_JOB_ID", None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
         requests.post(
             os.environ["JID_UPDATE_COUNTERS"],
             json=[

--- a/lcls2_producers/smd_producer.py
+++ b/lcls2_producers/smd_producer.py
@@ -1062,7 +1062,10 @@ logger.debug("rank {0} on {1} is finished".format(rank, hostname))
 #        cmd = ['timestamp_sort_h5', h5_f_name, h5_f_name]
 
 if ds.unique_user_rank():
-    if os.environ.get("ARP_JOB_ID", None) is not None and os.getenv("JID_UPDATE_COUNTERS") is not None:
+    if (
+        os.environ.get("ARP_JOB_ID", None) is not None
+        and os.getenv("JID_UPDATE_COUNTERS") is not None
+    ):
         requests.post(
             os.environ["JID_UPDATE_COUNTERS"],
             json=[

--- a/smalldata_tools/ana_funcs/azimuthalBinning.py
+++ b/smalldata_tools/ana_funcs/azimuthalBinning.py
@@ -239,7 +239,7 @@ class azimuthalBinning(DetObjectFunc):
         # include geometrical corrections
         geom = (self.dis_to_sam + self.z_off) / r
         # pixels are not perpendicular to scattered beam
-        geom *= ((self.dis_to_sam + self.z_off) / r)**2
+        geom *= ((self.dis_to_sam + self.z_off) / r) ** 2
         # scattered radiation is proportional to 1/r^2
         self.msg("calculating normalization...", cr=0)
         self.geom = geom

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -489,9 +489,17 @@ class Epix100Object(TiledCameraObject):
             30,
         ]  # Jacob (norm), Jacob, def, def(ami-like), mine, mine (norm), mine (norm-bank), none, raw, calib
         self.common_mode = kwargs.get("common_mode", self._common_mode_list[0])
-        if self.common_mode is None:
+        if isinstance(self.common_mode, tuple) or isinstance(self.common_mode, list):
+            self.common_mode = tuple(self.common_mode)
+            if len(self.common_mode) > 4:
+                print("Too many common mode parameters, taking only first 4!", self.common_mode)
+                self.common_mode = self.common_mode[:4]
+            elif len(self.common_mode) == 3:
+                print("Too few common mode parameters, but alg (cmpars[0]) is ignored. Extending!", self.common_mode)
+                self.common_mode = (0,) + self.common_mode
+        elif self.common_mode is None:
             self.common_mode = self._common_mode_list[0]
-        if self.common_mode not in self._common_mode_list:
+        elif self.common_mode not in self._common_mode_list:
             print(
                 "Common mode %d is not an option for as Epix detector, please choose from: "
                 % self.common_mode,
@@ -527,9 +535,13 @@ class Epix100Object(TiledCameraObject):
         mbits = 0  # do not apply mask (would set pixels to zero)
         # mbits=1 #set bad pixels to 0
 
+        if isinstance(self.common_mode, tuple):
+            self.evt.dat = self.det.raw.calib(
+                evt, cmpars=self.common_mode, rms=self.rms, normAll=True
+            )
         # Common Mode currently NOT working for ePix100
         # Skip all options that pass cmpars
-        if self.common_mode % 100 == 6:
+        elif self.common_mode % 100 == 6:
             # Was using cmpars=[6] -> This doesn't work for psana2
             # Some of these other kwargs may not do anything
             # self.evt.dat = self.det.raw.calib(

--- a/smalldata_tools/lcls2/DetObject.py
+++ b/smalldata_tools/lcls2/DetObject.py
@@ -492,10 +492,16 @@ class Epix100Object(TiledCameraObject):
         if isinstance(self.common_mode, tuple) or isinstance(self.common_mode, list):
             self.common_mode = tuple(self.common_mode)
             if len(self.common_mode) > 4:
-                print("Too many common mode parameters, taking only first 4!", self.common_mode)
+                print(
+                    "Too many common mode parameters, taking only first 4!",
+                    self.common_mode,
+                )
                 self.common_mode = self.common_mode[:4]
             elif len(self.common_mode) == 3:
-                print("Too few common mode parameters, but alg (cmpars[0]) is ignored. Extending!", self.common_mode)
+                print(
+                    "Too few common mode parameters, but alg (cmpars[0]) is ignored. Extending!",
+                    self.common_mode,
+                )
                 self.common_mode = (0,) + self.common_mode
         elif self.common_mode is None:
             self.common_mode = self._common_mode_list[0]


### PR DESCRIPTION
This PR adds a way to pass common-mode parameters for LCLS2. Currently only the ePix100 is supported - the interface is different from LCLS1, and the strategy in this PR is to opt for allowing passing the tuple directly (with the possibility to use the config function to pass more detector configuration in the future).

NOTE: Thsi requires waiting for a release of psana that supports common-mode, since it was previously broken for the ePix100 (and any two-dimensional detectors).

The PR also adds some minor guards against JID_UPDATE_COUNTERS failures when not running with the ARP.

Checklist
-------------
- [x] Initial common-mode support for LCLS2 detectors - specifically the ePix100
- [x] Guard for JIT_UPDATE_COUNTERS when not running from the ARP.

Testing
-------------
Tested through custom psana releases as part of LUTE workflows (the patches are applied automatically by the launch infrastructure).