### PR TITLE
Enh/mec adds

### DIFF
--- a/arp_scripts/submit_smd.sh
+++ b/arp_scripts/submit_smd.sh
@@ -23,6 +23,8 @@ $(basename "$0"):
             Number of cores to be utilized
         --maxnodes
             Max number of nodes to use
+        --mem
+            Memory per job (default is 4GB)
         -f|--full
             If specified, translate everything (do not use)
         -D|--default
@@ -74,6 +76,11 @@ do
         ;;
     --maxnodes)
         MAX_NODES="$2"
+        shift
+        shift
+        ;;
+    --mem)
+        MEM="$2"
         shift
         shift
         ;;
@@ -150,7 +157,7 @@ ARP_LOCATION="${ARP_LOCATION:=LOCAL}"
 export EXPERIMENT=$EXP
 export RUN_NUM=$RUN
 
-export MYDIR="$( builtin cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+export MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Default queue and S3DF flag
 DEFQUEUE='psanaq'
@@ -243,6 +250,9 @@ fi
 SBATCH_ARGS="-p $QUEUE --nodes 0-$MAX_NODES --ntasks $CORES --use-min-nodes -o $LOGFILE"
 MPI_CMD="mpirun -np $CORES python -u -m mpi4py.run ${ABS_PATH}/${PYTHONEXE} $*"
 
+if [ -v MEM ]; then
+    SBATCH_ARGS="$SBATCH_ARGS --mem ${MEM}"
+fi
 
 if [[ $QUEUE == *milano* ]]; then
     if [ -v RESERVATION ]; then

--- a/lcls1_producers/smd_producer.py
+++ b/lcls1_producers/smd_producer.py
@@ -468,7 +468,7 @@ else:
     epicsPVlist = ds.env().epicsStore().aliases()
 if (args.full or args.epicsAll) and len(epicsPVlist)>0:
     logger.debug('adding all epicsPVs....')
-    default_dets.append(epicsDetector(PVlist=epicsPV, name='epicsAll'))
+    default_dets.append(epicsDetector(PVlist=epicsPVlist, name='epicsAll'))
 #save specified list of PVs once/run, not nothing has been passed, save all.
 if len(config.epicsOncePV) > 0:
     EODet = epicsDetector(PVlist=epicsOncePV, name='epicsOnce')

--- a/smalldata_tools/ana_funcs/droplet2photons_gpu.py
+++ b/smalldata_tools/ana_funcs/droplet2photons_gpu.py
@@ -41,6 +41,8 @@ class droplet2photons_gpu(DetObjectFunc):
         # photpts[n] = n*aduspphot - offset  (identical convention to droplet2Photons)
         photpts = np.arange(1000000) * self.aduspphot - self.offset
         self.photpts = kwargs.get("photpts", photpts)
+        if self.aduspphot <= 0.:
+            self.aduspphot = np.median(self.photpts[1:]-self.photpts[:-1])
         self.use_gpu = bool(kwargs.get("use_gpu", False)) and _HAS_CUPY
         return
 
@@ -86,11 +88,13 @@ class droplet2photons_gpu(DetObjectFunc):
         }
         # photon_pts=None → find_photons sizes the (uniform) edges to the data; identical
         # classification to self.photpts, without shipping a 1e6 array to the GPU.
-        photons = find_photons(droplet_dict, float(self.aduspphot), photon_pts=None)
+
+        photons = find_photons(droplet_dict, float(self.aduspphot), photon_pts=self.photpts)
         if self.use_gpu:
             photons = photons.get()
 
         n = int(photons.shape[0])
+
         self.dat = {
             "tile": np.zeros(n),
             "row": photons[:, 0],

--- a/smalldata_tools/ana_funcs/droplet2photons_gpu.py
+++ b/smalldata_tools/ana_funcs/droplet2photons_gpu.py
@@ -41,8 +41,8 @@ class droplet2photons_gpu(DetObjectFunc):
         # photpts[n] = n*aduspphot - offset  (identical convention to droplet2Photons)
         photpts = np.arange(1000000) * self.aduspphot - self.offset
         self.photpts = kwargs.get("photpts", photpts)
-        if self.aduspphot <= 0.:
-            self.aduspphot = np.median(self.photpts[1:]-self.photpts[:-1])
+        if self.aduspphot <= 0.0:
+            self.aduspphot = np.median(self.photpts[1:] - self.photpts[:-1])
         self.use_gpu = bool(kwargs.get("use_gpu", False)) and _HAS_CUPY
         return
 
@@ -89,7 +89,9 @@ class droplet2photons_gpu(DetObjectFunc):
         # photon_pts=None → find_photons sizes the (uniform) edges to the data; identical
         # classification to self.photpts, without shipping a 1e6 array to the GPU.
 
-        photons = find_photons(droplet_dict, float(self.aduspphot), photon_pts=self.photpts)
+        photons = find_photons(
+            droplet_dict, float(self.aduspphot), photon_pts=self.photpts
+        )
         if self.use_gpu:
             photons = photons.get()
 


### PR DESCRIPTION
- add option to specify memory needed for job (MEC has events where the job fails to collect even with gather 1 & a single core)
- droplet2photons_gpu: calculate ADU per photon from photon list (if the former is not provided)&pass photon boundary list to find_photon function
- fix epicsPV list name for LCLS1 producer in full option.